### PR TITLE
Added Elite Upgrade: Push The Limit

### DIFF
--- a/Assets/Scripts/Model/Phases/SubPhases/ActionSubphase.cs
+++ b/Assets/Scripts/Model/Phases/SubPhases/ActionSubphase.cs
@@ -180,7 +180,8 @@ namespace SubPhases
         }
 
         public void ShowActionDecisionPanel()
-        {
+		{
+			Selection.ThisShip.IsFreeActionSkipped = false;
             List<ActionsList.GenericAction> availableActions = Selection.ThisShip.GetAvailableFreeActionsList();
             foreach (var action in availableActions)
             {
@@ -203,6 +204,7 @@ namespace SubPhases
         public override void SkipButton()
         {
             UI.HideSkipButton();
+			Selection.ThisShip.IsFreeActionSkipped = true;
             CallBack();
         }
 

--- a/Assets/Scripts/Model/Ships/GenericShip/GenericShipFlags.cs
+++ b/Assets/Scripts/Model/Ships/GenericShip/GenericShipFlags.cs
@@ -11,6 +11,8 @@ namespace Ship
         public bool IsAttackPerformed { get; set; }
         public bool IsDestroyed { get; set; }
         public bool IsSkipsActionSubPhase { get; set; }
+
+		public bool IsFreeActionSkipped { get; set; }
     } 
 
 }

--- a/Assets/Scripts/Model/Upgrades/Elite/PushTheLimit.cs
+++ b/Assets/Scripts/Model/Upgrades/Elite/PushTheLimit.cs
@@ -49,10 +49,15 @@ namespace UpgradesList
 		private void AddStressToken()
 		{
 			if (!base.Host.IsFreeActionSkipped) {
-				base.Host.AssignToken (new Tokens.StressToken(), Phases.CurrentSubPhase.CallBack);	
+				base.Host.AssignToken (new Tokens.StressToken(), delegate {
+					Phases.CurrentSubPhase.CallBack();
+					Triggers.FinishTrigger();
+				});	
 			}
-
-			Triggers.FinishTrigger();
+			else
+			{
+				Triggers.FinishTrigger();
+			}
 		}
 	}
 }

--- a/Assets/Scripts/Model/Upgrades/Elite/PushTheLimit.cs
+++ b/Assets/Scripts/Model/Upgrades/Elite/PushTheLimit.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Upgrade;
+
+namespace UpgradesList
+{
+	public class PushTheLimit : GenericUpgrade
+	{
+
+		public PushTheLimit() : base()
+		{
+			Type = UpgradeType.Elite;
+			Name = ShortName = "Push The Limit";
+			ImageUrl = "https://vignette3.wikia.nocookie.net/xwing-miniatures/images/5/59/Push_The_Limit.png";
+			Cost = 3;
+		}
+
+		public override void AttachToShip(Ship.GenericShip host)
+		{
+			base.AttachToShip(host);
+
+			host.OnActionDecisionSubphaseEnd += DoSecondAction;
+		}
+
+		private void DoSecondAction(Ship.GenericShip ship)
+		{
+			if (!ship.HasToken(typeof(Tokens.StressToken)))
+			{
+				Triggers.RegisterTrigger(
+					new Trigger()
+					{
+						Name = "Push The Limit Action",
+						TriggerOwner = ship.Owner.PlayerNo,
+						TriggerType = TriggerTypes.OnFreeAction,
+						EventHandler = PerformPushAction
+					}
+				);
+			}
+		}
+
+		private void PerformPushAction(object sender, System.EventArgs e)
+		{
+			base.Host.GenerateAvailableActionsList();
+			List<ActionsList.GenericAction> actions = Selection.ThisShip.GetAvailableActionsList();
+			base.Host.AskPerformFreeAction(actions, AddStressToken);
+		}
+
+		private void AddStressToken()
+		{
+			if (!base.Host.IsFreeActionSkipped) {
+				base.Host.AssignToken (new Tokens.StressToken(), Phases.CurrentSubPhase.CallBack);	
+			}
+
+			Triggers.FinishTrigger();
+		}
+	}
+}

--- a/Assets/Scripts/Model/Upgrades/Elite/PushTheLimit.cs.meta
+++ b/Assets/Scripts/Model/Upgrades/Elite/PushTheLimit.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 16bdb6356387645aa9885e49835d5610
+timeCreated: 1504238150
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
I think this is an okay way to handle this; added a new flag to indicate if the free action was skipped or not. If the PTL action is skipped; no stress is added. I didn't see another clear way to prevent this since it required knowledge of what was going on outside of the callback with respect to if the action was skipped or not.