### PR TITLE
Ion fix for large ships

### DIFF
--- a/Assets/Scripts/Model/Rules/RulesList/IonizationRule.cs
+++ b/Assets/Scripts/Model/Rules/RulesList/IonizationRule.cs
@@ -17,7 +17,12 @@ namespace RulesList
         {
             if (tokenType == typeof(IonToken))
             {
-                if (ship.GetToken(typeof(IonToken)).Count == 1)
+                if ((ship.GetToken(typeof(IonToken)).Count == 1) && ship.ShipBaseSize == BaseSize.Small )
+                {
+                    Messages.ShowError("Ship is ionized!");
+                    DoIonized(ship);
+                }
+                if ((ship.GetToken(typeof(IonToken)).Count == 2) && ship.ShipBaseSize == BaseSize.Large)
                 {
                     Messages.ShowError("Ship is ionized!");
                     DoIonized(ship);


### PR DESCRIPTION
Tested with a YT-1300 Large ship and a TIE Bomber. YT needed two ions, and bomber only one. Looks ok but I'm not that used to unity.