### PR TITLE
fix for wired reroll of 1+ dice but not 1

### DIFF
--- a/Assets/Scripts/Model/Upgrades/Elite/Wired.cs
+++ b/Assets/Scripts/Model/Upgrades/Elite/Wired.cs
@@ -70,7 +70,7 @@ namespace ActionsList
             DiceRerollManager diceRerollManager = new DiceRerollManager
             {
                 SidesCanBeRerolled = new System.Collections.Generic.List<DieSide> { DieSide.Focus },
-                NumberOfDiceCanBeRerolled = 1,
+                NumberOfDiceCanBeRerolled = 0,
                 CallBack = callBack
             };
             diceRerollManager.Start();


### PR DESCRIPTION
Tested locally and it allowed selection of all focus results instead of just 1. 

Since 0 selects all from the sidescanbererolled list afaik.