### PR TITLE
Subfactions and automatic loading of pilot card images

### DIFF
--- a/Assets/Scripts/MainMenu/Model/RosterBuilder.cs
+++ b/Assets/Scripts/MainMenu/Model/RosterBuilder.cs
@@ -946,10 +946,10 @@ public static partial class RosterBuilder {
 
         switch (faction)
         {
-            case Faction.Rebels:
+            case Faction.Rebel:
                 result = "rebel";
                 break;
-            case Faction.Empire:
+            case Faction.Imperial:
                 result = "imperial";
                 break;
             case Faction.Scum:

--- a/Assets/Scripts/MainMenu/View/RosterBuilder.cs
+++ b/Assets/Scripts/MainMenu/View/RosterBuilder.cs
@@ -374,15 +374,15 @@ public static partial class RosterBuilder {
 
     private static Faction GetPlayerFaction(PlayerNo playerNo)
     {
-        Faction result = Faction.Empire;
+        Faction result = Faction.Imperial;
         int index = GetPlayerPanel(playerNo).Find("GroupFaction/Dropdown").GetComponent<Dropdown>().value;
         switch (index)
         {
             case 0:
-                result = Faction.Rebels;
+                result = Faction.Rebel;
                 break;
             case 1:
-                result = Faction.Empire;
+                result = Faction.Imperial;
                 break;
             case 2:
                 result = Faction.Scum;

--- a/Assets/Scripts/Model/Global.cs
+++ b/Assets/Scripts/Model/Global.cs
@@ -149,7 +149,7 @@ public class Global : MonoBehaviour {
 
     public static Faction GetPlayerFaction(PlayerNo playerNo)
     {
-        Faction result = Faction.Rebels;
+        Faction result = Faction.Rebel;
         if (playerNo == PlayerNo.Player1) result = playerFactions[0];
         if (playerNo == PlayerNo.Player2) result = playerFactions[1];
         return result;

--- a/Assets/Scripts/Model/ImageUrls.cs
+++ b/Assets/Scripts/Model/ImageUrls.cs
@@ -19,7 +19,7 @@ public static class ImageUrls
 
     public static string GetImageUrl(Ship.GenericShip ship, string filename = null)
     {
-        return GetImageUrl(PilotsPath + FormatFaction(ship.faction) + "/" + ship.Type, ship.PilotName, filename);
+        return GetImageUrl(PilotsPath + FormatFaction(ship.SubFaction) + "/" + FormatShipType(ship.Type), ship.PilotName, filename);
     }
 
     private static string GetImageUrl(string subpath, string cardName, string filename)
@@ -27,15 +27,28 @@ public static class ImageUrls
         return RootURL + subpath + "/" + (filename ?? FormatName(cardName) + ".png");
     }
 
-    private static string FormatFaction(Faction faction)
+    private static string FormatShipType(string type)
+    {
+        return type
+            .Replace("-Wing", "-wing")
+            .Replace("/FO", "/fo")
+            .Replace("/SF", "/sf")
+            .Replace('/', '-');
+    }
+
+    private static string FormatFaction(SubFaction faction)
     {
         switch (faction)
         {
-            case Faction.Rebel:
+            case SubFaction.RebelAlliance:
                 return "Rebel Alliance";
-            case Faction.Imperial:
+            case SubFaction.Resistance:
+                return "Resistance";
+            case SubFaction.GalacticEmpire:
                 return "Galactic Empire";
-            case Faction.Scum:
+            case SubFaction.FirstOrder:
+                return "First Order";
+            case SubFaction.ScumAndVillainy:
                 return "Scum and Villainy";
             default:
                 throw new NotImplementedException();

--- a/Assets/Scripts/Model/ImageUrls.cs
+++ b/Assets/Scripts/Model/ImageUrls.cs
@@ -31,10 +31,12 @@ public static class ImageUrls
     {
         switch (faction)
         {
-            case Faction.Rebels:
+            case Faction.Rebel:
                 return "Rebel Alliance";
-            case Faction.Empire:
+            case Faction.Imperial:
                 return "Galactic Empire";
+            case Faction.Scum:
+                return "Scum and Villainy";
             default:
                 throw new NotImplementedException();
         }

--- a/Assets/Scripts/Model/ImageUrls.cs
+++ b/Assets/Scripts/Model/ImageUrls.cs
@@ -62,7 +62,9 @@ public static class ImageUrls
             .Replace("(", "")
             .Replace(")", "")
             .Replace(' ', '-')
-            .Replace('/', '-');
+            .Replace('/', '-')
+            .Replace('\'', '-')
+            .Replace("\"", "");
     }
 }
 

--- a/Assets/Scripts/Model/Players/GenericPlayer.cs
+++ b/Assets/Scripts/Model/Players/GenericPlayer.cs
@@ -6,9 +6,19 @@ using UnityEngine;
 public enum Faction
 {
     None,
-    Rebels,
-    Empire,
+    Rebel,
+    Imperial,
     Scum
+}
+
+public enum SubFaction
+{
+    None,
+    RebelAlliance,
+    Resistance,
+    GalacticEmpire,
+    FirstOrder,
+    ScumAndVillainy
 }
 
 namespace Players

--- a/Assets/Scripts/Model/Ships/A-Wing/AWing.cs
+++ b/Assets/Scripts/Model/Ships/A-Wing/AWing.cs
@@ -31,8 +31,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = new AI.AWingTable();
 
-                factions.Add(Faction.Rebels);
-                faction = Faction.Rebels;
+                factions.Add(Faction.Rebel);
+                faction = Faction.Rebel;
 
                 SkinName = "Red";
 

--- a/Assets/Scripts/Model/Ships/A-Wing/ArvelCrynyd.cs
+++ b/Assets/Scripts/Model/Ships/A-Wing/ArvelCrynyd.cs
@@ -7,7 +7,6 @@
             public ArvelCrynyd() : base()
             {
                 PilotName = "Arvel Crynyd";
-                ImageUrl = "https://vignette.wikia.nocookie.net/xwing-miniatures/images/e/e3/Arvel_Crynyd.png";
                 PilotSkill = 6;
                 Cost = 23;
 

--- a/Assets/Scripts/Model/Ships/A-Wing/GreenSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/A-Wing/GreenSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public GreenSquadronPilot() : base()
             {
                 PilotName = "Green Squadron Pilot";
-                ImageUrl = "https://vignette3.wikia.nocookie.net/xwing-miniatures/images/2/23/Green_Squadron_Pilot.png";
                 PilotSkill = 3;
                 Cost = 19;
 

--- a/Assets/Scripts/Model/Ships/A-Wing/PrototypePilot.cs
+++ b/Assets/Scripts/Model/Ships/A-Wing/PrototypePilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public PrototypePilot() : base()
             {
                 PilotName = "Prototype Pilot";
-                ImageUrl = "https://vignette2.wikia.nocookie.net/xwing-miniatures/images/f/fc/Prototype_Pilot.png";
                 PilotSkill = 1;
                 Cost = 17;
 

--- a/Assets/Scripts/Model/Ships/A-Wing/TychoCelchu.cs
+++ b/Assets/Scripts/Model/Ships/A-Wing/TychoCelchu.cs
@@ -7,7 +7,6 @@
             public TychoCelchu() : base()
             {
                 PilotName = "Tycho Celchu";
-                ImageUrl = "https://vignette.wikia.nocookie.net/xwing-miniatures/images/a/a7/Tycho_Celchu.png";
                 PilotSkill = 8;
                 Cost = 26;
 

--- a/Assets/Scripts/Model/Ships/ARC-170/ARC170.cs
+++ b/Assets/Scripts/Model/Ships/ARC-170/ARC170.cs
@@ -33,8 +33,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = null;
 
-                factions.Add(Faction.Rebels);
-                faction = Faction.Rebels;
+                factions.Add(Faction.Rebel);
+                faction = Faction.Rebel;
 
                 SkinName = "ARC-170";
 

--- a/Assets/Scripts/Model/Ships/Alpha-class Star Wing/AlphaClassStarWing.cs
+++ b/Assets/Scripts/Model/Ships/Alpha-class Star Wing/AlphaClassStarWing.cs
@@ -33,8 +33,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = new AI.AlphaClassStarWingTable();
 
-                factions.Add(Faction.Empire);
-                faction = Faction.Empire;
+                factions.Add(Faction.Imperial);
+                faction = Faction.Imperial;
 
                 SkinName = "Alpha-class Star Wing";
 

--- a/Assets/Scripts/Model/Ships/Alpha-class Star Wing/LieutenantKarsabi.cs
+++ b/Assets/Scripts/Model/Ships/Alpha-class Star Wing/LieutenantKarsabi.cs
@@ -13,7 +13,6 @@ namespace Ship
             public LieutenantKarsabi() : base()
             {
                 PilotName = "Lieutenant Karsabi";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/Alpha-class%20Star%20Wing/lieutenant-karsabi.png";
                 PilotSkill = 5;
                 Cost = 24;
 

--- a/Assets/Scripts/Model/Ships/Alpha-class Star Wing/MajorVynder.cs
+++ b/Assets/Scripts/Model/Ships/Alpha-class Star Wing/MajorVynder.cs
@@ -12,7 +12,6 @@ namespace Ship
             public MajorVynder() : base()
             {
                 PilotName = "Major Vynder";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/Alpha-class%20Star%20Wing/major-vynder.png";
                 PilotSkill = 7;
                 Cost = 26;
 

--- a/Assets/Scripts/Model/Ships/Alpha-class Star Wing/NuSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/Alpha-class Star Wing/NuSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public NuSquadronPilot() : base()
             {
                 PilotName = "Nu Squadron Pilot";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/Alpha-class%20Star%20Wing/nu-squadron-pilot.png";
                 PilotSkill = 2;
                 Cost = 18;
             }

--- a/Assets/Scripts/Model/Ships/Alpha-class Star Wing/RhoSquadronVeteran.cs
+++ b/Assets/Scripts/Model/Ships/Alpha-class Star Wing/RhoSquadronVeteran.cs
@@ -11,7 +11,6 @@ namespace Ship
             public RhoSquadronVeteran() : base()
             {
                 PilotName = "Rho Squadron Veteran";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/Alpha-class%20Star%20Wing/rho-squadron-veteran.png";
                 PilotSkill = 4;
                 Cost = 21;
 

--- a/Assets/Scripts/Model/Ships/Attack Shuttle/AttackShuttle.cs
+++ b/Assets/Scripts/Model/Ships/Attack Shuttle/AttackShuttle.cs
@@ -31,8 +31,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = null;
 
-                factions.Add(Faction.Rebels);
-                faction = Faction.Rebels;
+                factions.Add(Faction.Rebel);
+                faction = Faction.Rebel;
 
                 SkinName = "Attack Shuttle";
 

--- a/Assets/Scripts/Model/Ships/Auzituck Gunship/AuzituckGunship.cs
+++ b/Assets/Scripts/Model/Ships/Auzituck Gunship/AuzituckGunship.cs
@@ -32,8 +32,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = null;
 
-                factions.Add(Faction.Rebels);
-                faction = Faction.Rebels;
+                factions.Add(Faction.Rebel);
+                faction = Faction.Rebel;
 
                 SkinName = "Kashyyyk Defender";
 

--- a/Assets/Scripts/Model/Ships/Auzituck Gunship/KashyyykDefender.cs
+++ b/Assets/Scripts/Model/Ships/Auzituck Gunship/KashyyykDefender.cs
@@ -11,7 +11,6 @@ namespace Ship
             public KashyyykDefender() : base()
             {
                 PilotName = "Kashyyyk Defender";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Rebel%20Alliance/Auzituck%20Gunship/kashyyyk-defender.png";
                 PilotSkill = 1;
                 Cost = 24;
             }

--- a/Assets/Scripts/Model/Ships/Auzituck Gunship/Lowhhrick.cs
+++ b/Assets/Scripts/Model/Ships/Auzituck Gunship/Lowhhrick.cs
@@ -14,7 +14,6 @@ namespace Ship
             public Lowhhrick() : base()
             {
                 PilotName = "Lowhhrick";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Rebel%20Alliance/Auzituck%20Gunship/lowhhrick.png";
                 PilotSkill = 5;
                 Cost = 28;
 

--- a/Assets/Scripts/Model/Ships/Auzituck Gunship/WookieeLiberator.cs
+++ b/Assets/Scripts/Model/Ships/Auzituck Gunship/WookieeLiberator.cs
@@ -11,7 +11,6 @@ namespace Ship
             public WookieeLiberator() : base()
             {
                 PilotName = "Wookiee Liberator";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Rebel%20Alliance/Auzituck%20Gunship/wookiee-liberator.png";
                 PilotSkill = 3;
                 Cost = 26;
 

--- a/Assets/Scripts/Model/Ships/B-Wing/BWing.cs
+++ b/Assets/Scripts/Model/Ships/B-Wing/BWing.cs
@@ -33,8 +33,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = new AI.BWingTable();
 
-                factions.Add(Faction.Rebels);
-                faction = Faction.Rebels;
+                factions.Add(Faction.Rebel);
+                faction = Faction.Rebel;
 
                 SkinName = "Teal";
 

--- a/Assets/Scripts/Model/Ships/B-Wing/BlueSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/B-Wing/BlueSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public BlueSquadronPilot() : base()
             {
                 PilotName = "Blue Squadron Pilot";
-                ImageUrl = "https://vignette4.wikia.nocookie.net/xwing-miniatures/images/6/61/Blue-squadron-pilot.png";
                 PilotSkill = 2;
                 Cost = 22;
 

--- a/Assets/Scripts/Model/Ships/B-Wing/DaggerSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/B-Wing/DaggerSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public DaggerSquadronPilot() : base()
             {
                 PilotName = "Dagger Squadron Pilot";
-                ImageUrl = "https://vignette1.wikia.nocookie.net/xwing-miniatures/images/6/65/Dagger_Squadron.png";
                 PilotSkill = 4;
                 Cost = 24;
 

--- a/Assets/Scripts/Model/Ships/B-Wing/NeraDantels.cs
+++ b/Assets/Scripts/Model/Ships/B-Wing/NeraDantels.cs
@@ -12,7 +12,6 @@ namespace Ship
             public NeraDantels() : base()
             {
                 PilotName = "Nera Dantels";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Rebel%20Alliance/B-wing/nera-dantels.png";
                 PilotSkill = 5;
                 Cost = 26;
 

--- a/Assets/Scripts/Model/Ships/E-Wing/BlackmoonSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/E-Wing/BlackmoonSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public BlackmoonSquadronPilot() : base()
             {
                 PilotName = "Blackmoon Squadron Pilot";
-                ImageUrl = "https://vignette3.wikia.nocookie.net/xwing-miniatures/images/6/68/Pic2034070.png";
                 PilotSkill = 3;
                 Cost = 29;
             }

--- a/Assets/Scripts/Model/Ships/E-Wing/EWing.cs
+++ b/Assets/Scripts/Model/Ships/E-Wing/EWing.cs
@@ -33,8 +33,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = new AI.EWingTable();
 
-                factions.Add(Faction.Rebels);
-                faction = Faction.Rebels;
+                factions.Add(Faction.Rebel);
+                faction = Faction.Rebel;
 
                 SkinName = "Red";
 

--- a/Assets/Scripts/Model/Ships/E-Wing/KnaveSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/E-Wing/KnaveSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public KnaveSquadronPilot() : base()
             {
                 PilotName = "Knave Squadron Pilot";
-                ImageUrl = "https://vignette4.wikia.nocookie.net/xwing-miniatures/images/6/61/Knave-squadron-pilot.png";
                 PilotSkill = 1;
                 Cost = 27;
             }

--- a/Assets/Scripts/Model/Ships/Firespray-31/BobaFettEmpire.cs
+++ b/Assets/Scripts/Model/Ships/Firespray-31/BobaFettEmpire.cs
@@ -20,7 +20,7 @@ namespace Ship
 
                 PrintedUpgradeIcons.Add(Upgrade.UpgradeType.Elite);
 
-                faction = Faction.Empire;
+                faction = Faction.Imperial;
 
                 SkinName = "Boba Fett";
 

--- a/Assets/Scripts/Model/Ships/Firespray-31/BobaFettEmpire.cs
+++ b/Assets/Scripts/Model/Ships/Firespray-31/BobaFettEmpire.cs
@@ -12,7 +12,6 @@ namespace Ship
             public BobaFettEmpire() : base()
             {
                 PilotName = "Boba Fett";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/Firespray-31/boba-fett.png";
                 PilotSkill = 8;
                 Cost = 39;
 

--- a/Assets/Scripts/Model/Ships/Firespray-31/BountyHunter.cs
+++ b/Assets/Scripts/Model/Ships/Firespray-31/BountyHunter.cs
@@ -17,7 +17,7 @@ namespace Ship
 
                 SkinName = "Bounty Hunter";
 
-                faction = Faction.Empire;
+                faction = Faction.Imperial;
             }
         }
     }

--- a/Assets/Scripts/Model/Ships/Firespray-31/BountyHunter.cs
+++ b/Assets/Scripts/Model/Ships/Firespray-31/BountyHunter.cs
@@ -11,7 +11,6 @@ namespace Ship
             public BountyHunter() : base()
             {
                 PilotName = "Bounty Hunter";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/Firespray-31/bounty-hunter.png";
                 PilotSkill = 3;
                 Cost = 33;
 

--- a/Assets/Scripts/Model/Ships/Firespray-31/Firespray31.cs
+++ b/Assets/Scripts/Model/Ships/Firespray-31/Firespray31.cs
@@ -35,7 +35,7 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = new AI.Firespray31Table();
 
-                factions.Add(Faction.Empire);
+                factions.Add(Faction.Imperial);
                 factions.Add(Faction.Scum);
 
                 SoundShotsPath = "Slave1-Fire";

--- a/Assets/Scripts/Model/Ships/Firespray-31/KathScarlet.cs
+++ b/Assets/Scripts/Model/Ships/Firespray-31/KathScarlet.cs
@@ -19,7 +19,7 @@ namespace Ship
 
                 PrintedUpgradeIcons.Add(Upgrade.UpgradeType.Elite);
 
-                faction = Faction.Empire;
+                faction = Faction.Imperial;
 
                 SkinName = "Kath Scarlet";
 

--- a/Assets/Scripts/Model/Ships/Firespray-31/KathScarlet.cs
+++ b/Assets/Scripts/Model/Ships/Firespray-31/KathScarlet.cs
@@ -11,7 +11,6 @@ namespace Ship
             public KathScarletEmpire() : base()
             {
                 PilotName = "Kath Scarlet";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/Firespray-31/kath-scarlet.png";
                 PilotSkill = 7;
                 Cost = 38;
 

--- a/Assets/Scripts/Model/Ships/Firespray-31/KrassisTrelix.cs
+++ b/Assets/Scripts/Model/Ships/Firespray-31/KrassisTrelix.cs
@@ -13,7 +13,6 @@ namespace Ship
             public KrassisTrelix() : base()
             {
                 PilotName = "Krassis Trelix";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/Firespray-31/krassis-trelix.png";
                 PilotSkill = 5;
                 Cost = 36;
 

--- a/Assets/Scripts/Model/Ships/Firespray-31/KrassisTrelix.cs
+++ b/Assets/Scripts/Model/Ships/Firespray-31/KrassisTrelix.cs
@@ -21,7 +21,7 @@ namespace Ship
 
                 PilotAbilities.Add(new PilotAbilitiesNamespace.KrassisTrelixAbility());
 
-                faction = Faction.Empire;
+                faction = Faction.Imperial;
 
                 SkinName = "Krassis Trelix";
             }

--- a/Assets/Scripts/Model/Ships/Firespray-31/MandalorianMercenary.cs
+++ b/Assets/Scripts/Model/Ships/Firespray-31/MandalorianMercenary.cs
@@ -11,7 +11,6 @@ namespace Ship
             public MandalorianMercenary() : base()
             {
                 PilotName = "Mandalorian Mercenary";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/Firespray-31/bounty-hunter.png";
                 PilotSkill = 5;
                 Cost = 35;
 

--- a/Assets/Scripts/Model/Ships/G-1A Starfighter/GandFindsman.cs
+++ b/Assets/Scripts/Model/Ships/G-1A Starfighter/GandFindsman.cs
@@ -11,7 +11,6 @@ namespace Ship
             public GandFindsman() : base()
             {
                 PilotName = "Gand Findsman";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/G-1A%20Starfighter/gand-findsman.png";
                 PilotSkill = 5;
                 Cost = 25;
 

--- a/Assets/Scripts/Model/Ships/G-1A Starfighter/RuthlessFreelancer.cs
+++ b/Assets/Scripts/Model/Ships/G-1A Starfighter/RuthlessFreelancer.cs
@@ -11,7 +11,6 @@ namespace Ship
             public RuthlessFreelancer() : base()
             {
                 PilotName = "Ruthless Freelancer";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/G-1A%20Starfighter/ruthless-freelancer.png";
                 PilotSkill = 3;
                 Cost = 23;
             }

--- a/Assets/Scripts/Model/Ships/GenericShip/GenericShipCore.cs
+++ b/Assets/Scripts/Model/Ships/GenericShip/GenericShipCore.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using Arcs;
 using PilotAbilitiesNamespace;
+using System;
 
 namespace Ship
 {
@@ -24,6 +25,36 @@ namespace Ship
 
         public Faction faction { get; protected set; }
         public List<Faction> factions { get; protected set; }
+
+        private SubFaction? subFaction { get; set; }
+        public SubFaction SubFaction
+        {
+            get
+            {
+                if (subFaction != null)
+                {
+                    return subFaction.Value;
+                }
+                else
+                {
+                    switch (faction)
+                    {
+                        case Faction.Imperial:
+                            return SubFaction.GalacticEmpire;
+                        case Faction.Rebel:
+                            return SubFaction.RebelAlliance;
+                        case Faction.Scum:
+                            return SubFaction.ScumAndVillainy;
+                        default:
+                            throw new NotImplementedException("Invalid faction: " + faction.ToString());
+                    }
+                }
+            }
+            set
+            {
+                subFaction = value;
+            }
+        }
         
         public string PilotName { get; protected set; }
         public bool IsUnique { get; protected set; }

--- a/Assets/Scripts/Model/Ships/HWK-290/HWK290.cs
+++ b/Assets/Scripts/Model/Ships/HWK-290/HWK290.cs
@@ -30,7 +30,7 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = new AI.HWK290Table();
 
-                factions.Add(Faction.Rebels);
+                factions.Add(Faction.Rebel);
                 factions.Add(Faction.Scum);
 
                 SkinName = "Brown";

--- a/Assets/Scripts/Model/Ships/HWK-290/JanOrs.cs
+++ b/Assets/Scripts/Model/Ships/HWK-290/JanOrs.cs
@@ -20,7 +20,7 @@ namespace Ship
 
                 PrintedUpgradeIcons.Add(Upgrade.UpgradeType.Elite);
 
-                faction = Faction.Rebels;
+                faction = Faction.Rebel;
 
                 PilotAbilities.Add(new PilotAbilitiesNamespace.JanOrsAbility());
             }

--- a/Assets/Scripts/Model/Ships/HWK-290/JanOrs.cs
+++ b/Assets/Scripts/Model/Ships/HWK-290/JanOrs.cs
@@ -12,7 +12,6 @@ namespace Ship
             public JanOrs() : base()
             {
                 PilotName = "Jan Ors";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Rebel%20Alliance/HWK-290/jan-ors.png";
                 PilotSkill = 8;
                 Cost = 25;
 

--- a/Assets/Scripts/Model/Ships/HWK-290/RebelOperative.cs
+++ b/Assets/Scripts/Model/Ships/HWK-290/RebelOperative.cs
@@ -11,7 +11,6 @@ namespace Ship
             public RebelOperative() : base()
             {
                 PilotName = "Rebel Operative";
-                ImageUrl = "https://vignette3.wikia.nocookie.net/xwing-miniatures/images/e/ea/Rebel_Operative.png";
                 PilotSkill = 2;
                 Cost = 16;
 

--- a/Assets/Scripts/Model/Ships/HWK-290/RebelOperative.cs
+++ b/Assets/Scripts/Model/Ships/HWK-290/RebelOperative.cs
@@ -15,7 +15,7 @@ namespace Ship
                 PilotSkill = 2;
                 Cost = 16;
 
-                faction = Faction.Rebels;
+                faction = Faction.Rebel;
             }
         }
     }

--- a/Assets/Scripts/Model/Ships/HWK-290/SpiceRunner.cs
+++ b/Assets/Scripts/Model/Ships/HWK-290/SpiceRunner.cs
@@ -11,7 +11,6 @@ namespace Ship
             public SpiceRunner() : base()
             {
                 PilotName = "Spice Runner";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/HWK-290/spice-runner.png";
                 PilotSkill = 1;
                 Cost = 16;
 

--- a/Assets/Scripts/Model/Ships/JumpMaster 5000/ContractedScout.cs
+++ b/Assets/Scripts/Model/Ships/JumpMaster 5000/ContractedScout.cs
@@ -11,7 +11,6 @@ namespace Ship
             public ContractedScout() : base()
             {
                 PilotName = "Contracted Scout";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/JumpMaster%205000/contracted-scout.png";
                 PilotSkill = 3;
                 Cost = 25;
             }

--- a/Assets/Scripts/Model/Ships/K-Wing/GuardianSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/K-Wing/GuardianSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public GuardianSquadronPilot() : base()
             {
                 PilotName = "Guardian Squadron Pilot";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Rebel%20Alliance/K-wing/guardian-squadron-pilot.png";
                 PilotSkill = 4;
                 Cost = 25;
             }

--- a/Assets/Scripts/Model/Ships/K-Wing/KWing.cs
+++ b/Assets/Scripts/Model/Ships/K-Wing/KWing.cs
@@ -38,8 +38,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = null;
 
-                factions.Add(Faction.Rebels);
-                faction = Faction.Rebels;
+                factions.Add(Faction.Rebel);
+                faction = Faction.Rebel;
 
                 SkinName = "White";
 

--- a/Assets/Scripts/Model/Ships/K-Wing/WardenSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/K-Wing/WardenSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public WardenSquadronPilot() : base()
             {
                 PilotName = "Warden Squadron Pilot";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Rebel%20Alliance/K-wing/warden-squadron-pilot.png";
                 PilotSkill = 2;
                 Cost = 23;
             }

--- a/Assets/Scripts/Model/Ships/Kihraxz/BlackSunAce.cs
+++ b/Assets/Scripts/Model/Ships/Kihraxz/BlackSunAce.cs
@@ -11,7 +11,6 @@ namespace Ship
             public BlackSunAce() : base()
             {
                 PilotName = "Black Sun Ace";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/Kihraxz%20Fighter/black-sun-ace.png";
                 PilotSkill = 5;
                 Cost = 23;
 

--- a/Assets/Scripts/Model/Ships/Kihraxz/CartelMarauder.cs
+++ b/Assets/Scripts/Model/Ships/Kihraxz/CartelMarauder.cs
@@ -11,7 +11,6 @@ namespace Ship
             public CartelMarauder() : base()
             {
                 PilotName = "Cartel Marauder";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/Kihraxz%20Fighter/cartel-marauder.png";
                 PilotSkill = 2;
                 Cost = 20;
             }

--- a/Assets/Scripts/Model/Ships/Kihraxz/Kihraxz.cs
+++ b/Assets/Scripts/Model/Ships/Kihraxz/Kihraxz.cs
@@ -13,7 +13,7 @@ namespace Ship
 
             public Kihraxz() : base()
             {
-                Type = "Kihraxz";
+                Type = "Kihraxz Fighter";
 
                 ManeuversImageUrl = "https://vignette.wikia.nocookie.net/xwing-miniatures/images/d/d8/MS_KIHRAXZ-FIGHTER.png";
 

--- a/Assets/Scripts/Model/Ships/LambdaShuttle/LambdaShuttle.cs
+++ b/Assets/Scripts/Model/Ships/LambdaShuttle/LambdaShuttle.cs
@@ -33,8 +33,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = new AI.LambdaShuttleTable();
 
-                factions.Add(Faction.Empire);
-                faction = Faction.Empire;
+                factions.Add(Faction.Imperial);
+                faction = Faction.Imperial;
 
                 SkinName = "Lambda-class Shuttle";
 

--- a/Assets/Scripts/Model/Ships/Lancer-class Pursuit Craft/ShadowportHunter.cs
+++ b/Assets/Scripts/Model/Ships/Lancer-class Pursuit Craft/ShadowportHunter.cs
@@ -11,7 +11,6 @@ namespace Ship
             public ShadowportHunter() : base()
             {
                 PilotName = "Shadowport Hunter";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/Lancer-class%20Pursuit%20Craft/shadowport-hunter.png";
                 PilotSkill = 2;
                 Cost = 33;
             }

--- a/Assets/Scripts/Model/Ships/M12-L Kimogila/CartelBrute.cs
+++ b/Assets/Scripts/Model/Ships/M12-L Kimogila/CartelBrute.cs
@@ -11,7 +11,6 @@ namespace Ship
             public CartelBrute() : base()
             {
                 PilotName = "Cartel Brute";
-                ImageUrl = "https://images-cdn.fantasyflightgames.com/filer_public/b5/3a/b53ada87-4b50-4a18-94cc-183f6b3565ef/swx70-cartel-brute.png";
                 PilotSkill = 3;
                 Cost = 22;
             }

--- a/Assets/Scripts/Model/Ships/M12-L Kimogila/DalanOberos.cs
+++ b/Assets/Scripts/Model/Ships/M12-L Kimogila/DalanOberos.cs
@@ -12,7 +12,6 @@ namespace Ship
             public DalanOberos() : base()
             {
                 PilotName = "Dalan Oberos";
-                ImageUrl = "https://images-cdn.fantasyflightgames.com/filer_public/19/b3/19b3a603-f973-4064-ab69-fdf72f6d79e8/swx70-dalan-oberos.png";
                 PilotSkill = 7;
                 Cost = 25;
 

--- a/Assets/Scripts/Model/Ships/M12-L Kimogila/M12LKimogila.cs
+++ b/Assets/Scripts/Model/Ships/M12-L Kimogila/M12LKimogila.cs
@@ -13,7 +13,7 @@ namespace Ship
 
             public M12LKimogila() : base()
             {
-                Type = "M12-L Kimogila";
+                Type = "M12-L Kimogila Fighter";
 
                 ShipBaseArcsType = Arcs.BaseArcsType.ArcBullseye;
 

--- a/Assets/Scripts/Model/Ships/M12-L Kimogila/ToraniKulda.cs
+++ b/Assets/Scripts/Model/Ships/M12-L Kimogila/ToraniKulda.cs
@@ -15,7 +15,6 @@ namespace Ship
             public ToraniKulda() : base()
             {
                 PilotName = "Torani Kulda";
-                ImageUrl = "https://images-cdn.fantasyflightgames.com/filer_public/23/8d/238d3ebc-519d-4593-884b-3379d72e5f60/swx70-torani-kulda.png";
                 PilotSkill = 8;
                 Cost = 27;
 

--- a/Assets/Scripts/Model/Ships/M3-A Interceptor/CartelSpacer.cs
+++ b/Assets/Scripts/Model/Ships/M3-A Interceptor/CartelSpacer.cs
@@ -11,7 +11,6 @@ namespace Ship
             public CartelSpacer() : base()
             {
                 PilotName = "Cartel Spacer";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/M3-A%20Interceptor/cartel-spacer.png";
                 PilotSkill = 2;
                 Cost = 14;
             }

--- a/Assets/Scripts/Model/Ships/M3-A Interceptor/TansariiPointVeteran.cs
+++ b/Assets/Scripts/Model/Ships/M3-A Interceptor/TansariiPointVeteran.cs
@@ -11,7 +11,6 @@ namespace Ship
             public TansariiPointVeteran() : base()
             {
                 PilotName = "Tansarii Point Veteran";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/M3-A%20Interceptor/tansarii-point-veteran.png";
                 PilotSkill = 5;
                 Cost = 17;
 

--- a/Assets/Scripts/Model/Ships/Protectorate Starfighter/ConcordDawnAce.cs
+++ b/Assets/Scripts/Model/Ships/Protectorate Starfighter/ConcordDawnAce.cs
@@ -11,7 +11,6 @@ namespace Ship
             public ConcordDawnAce() : base()
             {
                 PilotName = "Concord Dawn Ace";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/Protectorate%20Starfighter/concord-dawn-ace.png";
                 PilotSkill = 5;
                 Cost = 24;
 

--- a/Assets/Scripts/Model/Ships/Protectorate Starfighter/ConcordDawnVeteran.cs
+++ b/Assets/Scripts/Model/Ships/Protectorate Starfighter/ConcordDawnVeteran.cs
@@ -11,7 +11,6 @@ namespace Ship
             public ConcordDawnVeteran() : base()
             {
                 PilotName = "Concord Dawn Veteran";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/Protectorate%20Starfighter/concord-dawn-veteran.png";
                 PilotSkill = 3;
                 Cost = 22;
 

--- a/Assets/Scripts/Model/Ships/Protectorate Starfighter/FennRau.cs
+++ b/Assets/Scripts/Model/Ships/Protectorate Starfighter/FennRau.cs
@@ -11,7 +11,6 @@ namespace Ship
             public FennRau() : base()
             {
                 PilotName = "Fenn Rau";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/Protectorate%20Starfighter/fenn-rau.png";
                 PilotSkill = 9;
                 Cost = 28;
 

--- a/Assets/Scripts/Model/Ships/Protectorate Starfighter/ZealousRecruit.cs
+++ b/Assets/Scripts/Model/Ships/Protectorate Starfighter/ZealousRecruit.cs
@@ -11,7 +11,6 @@ namespace Ship
             public ZealousRecruit() : base()
             {
                 PilotName = "Zealous Recruit";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/Protectorate%20Starfighter/zealous-recruit.png";
                 PilotSkill = 1;
                 Cost = 20;
             }

--- a/Assets/Scripts/Model/Ships/Quadjumper/JakkuGunrunner.cs
+++ b/Assets/Scripts/Model/Ships/Quadjumper/JakkuGunrunner.cs
@@ -11,7 +11,6 @@ namespace Ship
             public JakkuGunrunner() : base()
             {
                 PilotName = "Jakku Gunrunner";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/Quadjumper/jakku-gunrunner.png";
                 PilotSkill = 1;
                 Cost = 15;
             }

--- a/Assets/Scripts/Model/Ships/Scurrg H-6 Bomber/KarthakkPirate.cs
+++ b/Assets/Scripts/Model/Ships/Scurrg H-6 Bomber/KarthakkPirate.cs
@@ -11,7 +11,6 @@ namespace Ship
             public KarthakkPirate() : base()
             {
                 PilotName = "Karthakk Pirate";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/Scurrg%20H-6%20Bomber/karthakk-pirate.png";
                 PilotSkill = 1;
                 Cost = 24;
 

--- a/Assets/Scripts/Model/Ships/Scurrg H-6 Bomber/LokRevenant.cs
+++ b/Assets/Scripts/Model/Ships/Scurrg H-6 Bomber/LokRevenant.cs
@@ -11,7 +11,6 @@ namespace Ship
             public LokRevenant() : base()
             {
                 PilotName = "Lok Revenant";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/Scurrg%20H-6%20Bomber/lok-revenant.png";
                 PilotSkill = 3;
                 Cost = 26;
 

--- a/Assets/Scripts/Model/Ships/StarViper/BlackSunAssassin.cs
+++ b/Assets/Scripts/Model/Ships/StarViper/BlackSunAssassin.cs
@@ -11,7 +11,6 @@ namespace Ship
             public BlackSunAssassin() : base()
             {
                 PilotName = "Black Sun Assassin";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/StarViper/black-sun-assassin.png";
                 PilotSkill = 5;
                 Cost = 28;
 

--- a/Assets/Scripts/Model/Ships/StarViper/BlackSunEnforcer.cs
+++ b/Assets/Scripts/Model/Ships/StarViper/BlackSunEnforcer.cs
@@ -11,7 +11,6 @@ namespace Ship
             public BlackSunEnforcer() : base()
             {
                 PilotName = "Black Sun Enforcer";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/StarViper/black-sun-enforcer.png";
                 PilotSkill = 1;
                 Cost = 25;
             }

--- a/Assets/Scripts/Model/Ships/StarViper/BlackSunVigo.cs
+++ b/Assets/Scripts/Model/Ships/StarViper/BlackSunVigo.cs
@@ -11,7 +11,6 @@ namespace Ship
             public BlackSunVigo() : base()
             {
                 PilotName = "Black Sun Vigo";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/StarViper/black-sun-vigo.png";
                 PilotSkill = 3;
                 Cost = 27;
 

--- a/Assets/Scripts/Model/Ships/StarViper/Thweek.cs
+++ b/Assets/Scripts/Model/Ships/StarViper/Thweek.cs
@@ -14,7 +14,6 @@ namespace Ship
             public Thweek() : base()
             {
                 PilotName = "Thweek";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/StarViper/thweek.png";
                 PilotSkill = 4;
                 Cost = 28;
 

--- a/Assets/Scripts/Model/Ships/T-70 X-Wing/BlueSquadronNovice.cs
+++ b/Assets/Scripts/Model/Ships/T-70 X-Wing/BlueSquadronNovice.cs
@@ -11,9 +11,9 @@ namespace Ship
             public BlueSquadronNovice() : base()
             {
                 PilotName = "Blue Squadron Novice";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Resistance/T-70%20X-wing/blue-squadron-novice.png";
                 PilotSkill = 2;
                 Cost = 24;
+                SubFaction = SubFaction.Resistance;
             }
         }
     }

--- a/Assets/Scripts/Model/Ships/T-70 X-Wing/BlueSquadronNovice.cs
+++ b/Assets/Scripts/Model/Ships/T-70 X-Wing/BlueSquadronNovice.cs
@@ -13,7 +13,6 @@ namespace Ship
                 PilotName = "Blue Squadron Novice";
                 PilotSkill = 2;
                 Cost = 24;
-                SubFaction = SubFaction.Resistance;
             }
         }
     }

--- a/Assets/Scripts/Model/Ships/T-70 X-Wing/RedSquadronVeteran.cs
+++ b/Assets/Scripts/Model/Ships/T-70 X-Wing/RedSquadronVeteran.cs
@@ -11,7 +11,6 @@ namespace Ship
             public RedSquadronVeteran() : base()
             {
                 PilotName = "Red Squadron Veteran";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Resistance/T-70%20X-wing/red-squadron-veteran.png";
                 PilotSkill = 4;
                 Cost = 26;
 

--- a/Assets/Scripts/Model/Ships/T-70 X-Wing/T70XWing.cs
+++ b/Assets/Scripts/Model/Ships/T-70 X-Wing/T70XWing.cs
@@ -32,8 +32,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = null;
 
-                factions.Add(Faction.Rebels);
-                faction = Faction.Rebels;
+                factions.Add(Faction.Rebel);
+                faction = Faction.Rebel;
 
                 SkinName = "Blue";
 

--- a/Assets/Scripts/Model/Ships/T-70 X-Wing/T70XWing.cs
+++ b/Assets/Scripts/Model/Ships/T-70 X-Wing/T70XWing.cs
@@ -22,6 +22,8 @@ namespace Ship
                 MaxHull = 3;
                 MaxShields = 3;
 
+                SubFaction = SubFaction.Resistance;
+
                 PrintedUpgradeIcons.Add(Upgrade.UpgradeType.Astromech);
                 PrintedUpgradeIcons.Add(Upgrade.UpgradeType.Torpedo);
                 PrintedUpgradeIcons.Add(Upgrade.UpgradeType.Tech);

--- a/Assets/Scripts/Model/Ships/TIE Adv. Prototype/BaronOfTheEmpire.cs
+++ b/Assets/Scripts/Model/Ships/TIE Adv. Prototype/BaronOfTheEmpire.cs
@@ -11,7 +11,6 @@ namespace Ship
             public BaronOfTheEmpire() : base()
             {
                 PilotName = "Baron of the Empire";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/TIE%20Adv.%20Prototype/baron-of-the-empire.png";
                 PilotSkill = 4;
                 Cost = 19;
 

--- a/Assets/Scripts/Model/Ships/TIE Adv. Prototype/SienarTestPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE Adv. Prototype/SienarTestPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public SienarTestPilot() : base()
             {
                 PilotName = "Sienar Test Pilot";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/TIE%20Adv.%20Prototype/sienar-test-pilot.png";
                 PilotSkill = 2;
                 Cost = 16;
             }

--- a/Assets/Scripts/Model/Ships/TIE Adv. Prototype/TIEAdvPrototype.cs
+++ b/Assets/Scripts/Model/Ships/TIE Adv. Prototype/TIEAdvPrototype.cs
@@ -31,8 +31,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = null;
 
-                factions.Add(Faction.Empire);
-                faction = Faction.Empire;
+                factions.Add(Faction.Imperial);
+                faction = Faction.Imperial;
 
                 SkinName = "White";
 

--- a/Assets/Scripts/Model/Ships/TIE Adv. Prototype/TheInquisitor.cs
+++ b/Assets/Scripts/Model/Ships/TIE Adv. Prototype/TheInquisitor.cs
@@ -12,7 +12,6 @@ namespace Ship
             public TheInquisitor() : base()
             {
                 PilotName = "The Inquisitor";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/TIE%20Adv.%20Prototype/the-inquisitor.png";
                 PilotSkill = 8;
                 Cost = 25;
 

--- a/Assets/Scripts/Model/Ships/TIE Advanced/DarthVader.cs
+++ b/Assets/Scripts/Model/Ships/TIE Advanced/DarthVader.cs
@@ -15,7 +15,6 @@ namespace Ship
             public DarthVader() : base()
             {
                 PilotName = "Darth Vader";
-                ImageUrl = "https://vignette1.wikia.nocookie.net/xwing-miniatures/images/f/f7/Darth_Vader.png";
                 PilotSkill = 9;
                 Cost = 29;
 

--- a/Assets/Scripts/Model/Ships/TIE Advanced/MaarekStele.cs
+++ b/Assets/Scripts/Model/Ships/TIE Advanced/MaarekStele.cs
@@ -16,7 +16,6 @@ namespace Ship
                 IsHidden = true;
 
                 PilotName = "Maarek Stele";
-                ImageUrl = "https://vignette3.wikia.nocookie.net/xwing-miniatures/images/4/41/Maarek_Stele.png";
                 PilotSkill = 7;
                 Cost = 27;
 

--- a/Assets/Scripts/Model/Ships/TIE Advanced/StormSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE Advanced/StormSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public StormSquadronPilot() : base()
             {
                 PilotName = "Storm Squadron Pilot";
-                ImageUrl = "https://vignette3.wikia.nocookie.net/xwing-miniatures/images/6/67/Storm_Squadron_Pilot.jpg";
                 PilotSkill = 4;
                 Cost = 23;
             }

--- a/Assets/Scripts/Model/Ships/TIE Advanced/TIEAdvanced.cs
+++ b/Assets/Scripts/Model/Ships/TIE Advanced/TIEAdvanced.cs
@@ -31,8 +31,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = new AI.TIEAdvancedTable();
 
-                factions.Add(Faction.Empire);
-                faction = Faction.Empire;
+                factions.Add(Faction.Imperial);
+                faction = Faction.Imperial;
 
                 SkinName = "Gray";
 

--- a/Assets/Scripts/Model/Ships/TIE Advanced/TempestSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE Advanced/TempestSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public TempestSquadronPilot() : base()
             {
                 PilotName = "Tempest Squadron Pilot";
-                ImageUrl = "https://vignette1.wikia.nocookie.net/xwing-miniatures/images/9/93/Tempest_Squadron_Pilot.jpg";
                 PilotSkill = 2;
                 Cost = 21;
             }

--- a/Assets/Scripts/Model/Ships/TIE Agressor/OnyxSquadronEscort.cs
+++ b/Assets/Scripts/Model/Ships/TIE Agressor/OnyxSquadronEscort.cs
@@ -11,7 +11,6 @@ namespace Ship
             public OnyxSquadronEscort() : base()
             {
                 PilotName = "Onyx Squadron Escort";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/TIE%20Aggressor/onyx-squadron-escort.png";
                 PilotSkill = 5;
                 Cost = 19;
             }

--- a/Assets/Scripts/Model/Ships/TIE Agressor/SienarSpecialist.cs
+++ b/Assets/Scripts/Model/Ships/TIE Agressor/SienarSpecialist.cs
@@ -11,7 +11,6 @@ namespace Ship
             public SienarSpecialist() : base()
             {
                 PilotName = "Sienar Specialist";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/TIE%20Aggressor/sienar-specialist.png";
                 PilotSkill = 2;
                 Cost = 17;
             }

--- a/Assets/Scripts/Model/Ships/TIE Agressor/TIEAgressor.cs
+++ b/Assets/Scripts/Model/Ships/TIE Agressor/TIEAgressor.cs
@@ -32,8 +32,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = null;
 
-                factions.Add(Faction.Empire);
-                faction = Faction.Empire;
+                factions.Add(Faction.Imperial);
+                faction = Faction.Imperial;
 
                 SkinName = "Gray";
 

--- a/Assets/Scripts/Model/Ships/TIE Bomber/GammaSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE Bomber/GammaSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public GammaSquadronPilot() : base()
             {
                 PilotName = "Gamma Squadron Pilot";
-                ImageUrl = "https://vignette2.wikia.nocookie.net/xwing-miniatures/images/d/d0/Gamma_Squadron_Pilot.png";
                 PilotSkill = 4;
                 Cost = 18;
 

--- a/Assets/Scripts/Model/Ships/TIE Bomber/GammaSquadronVeteran.cs
+++ b/Assets/Scripts/Model/Ships/TIE Bomber/GammaSquadronVeteran.cs
@@ -11,7 +11,6 @@ namespace Ship
             public GammaSquadronVeteran() : base()
             {
                 PilotName = "Gamma Squadron Veteran";
-                ImageUrl = "https://vignette3.wikia.nocookie.net/xwing-miniatures/images/b/bd/Swx52-gamma-squad-vet.png";
                 PilotSkill = 5;
                 Cost = 19;
 

--- a/Assets/Scripts/Model/Ships/TIE Bomber/ScimitarSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE Bomber/ScimitarSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public ScimitarSquadronPilot() : base()
             {
                 PilotName = "Scimitar Squadron Pilot";
-                ImageUrl = "https://vignette3.wikia.nocookie.net/xwing-miniatures/images/a/a3/Scimitar-squadron-pilot.png";
                 PilotSkill = 2;
                 Cost = 16;
             }

--- a/Assets/Scripts/Model/Ships/TIE Bomber/TIEBomber.cs
+++ b/Assets/Scripts/Model/Ships/TIE Bomber/TIEBomber.cs
@@ -34,8 +34,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = new AI.TIEBomberTable();
 
-                factions.Add(Faction.Empire);
-                faction = Faction.Empire;
+                factions.Add(Faction.Imperial);
+                faction = Faction.Imperial;
 
                 SkinName = "Blue";
 

--- a/Assets/Scripts/Model/Ships/TIE Defender/ColonelVessery.cs
+++ b/Assets/Scripts/Model/Ships/TIE Defender/ColonelVessery.cs
@@ -11,7 +11,6 @@ namespace Ship
             public ColonelVessery() : base()
             {
                 PilotName = "Colonel Vessery";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/TIE%20Defender/colonel-vessery.png";
                 PilotSkill = 6;
                 Cost = 35;
 

--- a/Assets/Scripts/Model/Ships/TIE Defender/DeltaSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE Defender/DeltaSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public DeltaSquadronPilot() : base()
             {
                 PilotName = "Delta Squadron Pilot";
-                ImageUrl = "https://vignette1.wikia.nocookie.net/xwing-miniatures/images/8/81/Delta-squadron-pilot.png";
                 PilotSkill = 1;
                 Cost = 30;
             }

--- a/Assets/Scripts/Model/Ships/TIE Defender/GlaiveSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE Defender/GlaiveSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public GlaiveSquadronPilot() : base()
             {
                 PilotName = "Glaive Squadron Pilot";
-                ImageUrl = "https://vignette4.wikia.nocookie.net/xwing-miniatures/images/5/59/Swx52-glaive-squadron-pilot.png";
                 PilotSkill = 6;
                 Cost = 34;
 

--- a/Assets/Scripts/Model/Ships/TIE Defender/OnyxSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE Defender/OnyxSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public OnyxSquadronPilot() : base()
             {
                 PilotName = "Onyx Squadron Pilot";
-                ImageUrl = "https://vignette2.wikia.nocookie.net/xwing-miniatures/images/f/f0/Onyx_Squadron_Pilot.jpg";
                 PilotSkill = 3;
                 Cost = 32;
             }

--- a/Assets/Scripts/Model/Ships/TIE Defender/TIEDefender.cs
+++ b/Assets/Scripts/Model/Ships/TIE Defender/TIEDefender.cs
@@ -31,8 +31,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = new AI.TIEDefenderTable();
 
-                factions.Add(Faction.Empire);
-                faction = Faction.Empire;
+                factions.Add(Faction.Imperial);
+                faction = Faction.Imperial;
 
                 SkinName = "Blue";
 

--- a/Assets/Scripts/Model/Ships/TIE FO/EpsilonLeader.cs
+++ b/Assets/Scripts/Model/Ships/TIE FO/EpsilonLeader.cs
@@ -14,7 +14,6 @@ namespace Ship
 				PilotName = "Epsilon Leader";
 				PilotSkill = 6;
 				Cost = 19;
-                SubFaction = SubFaction.FirstOrder;
 
                 IsUnique = true;
                 PilotAbilities.Add(new PilotAbilitiesNamespace.EpsilonLeader());

--- a/Assets/Scripts/Model/Ships/TIE FO/EpsilonLeader.cs
+++ b/Assets/Scripts/Model/Ships/TIE FO/EpsilonLeader.cs
@@ -12,12 +12,11 @@ namespace Ship
 			public EpsilonLeader () : base ()
 			{
 				PilotName = "Epsilon Leader";
-				ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/First%20Order/TIE-fo%20Fighter/epsilon-leader.png";
 				PilotSkill = 6;
 				Cost = 19;
+                SubFaction = SubFaction.FirstOrder;
 
                 IsUnique = true;
-
                 PilotAbilities.Add(new PilotAbilitiesNamespace.EpsilonLeader());
             }
 		}

--- a/Assets/Scripts/Model/Ships/TIE FO/EpsilonSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE FO/EpsilonSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public EpsilonSquadronPilot() : base()
             {
                 PilotName = "Epsilon Squadron Pilot";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/First%20Order/TIE-fo%20Fighter/epsilon-squadron-pilot.png";
                 PilotSkill = 1;
                 Cost = 15;
             }

--- a/Assets/Scripts/Model/Ships/TIE FO/OmegaSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE FO/OmegaSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public OmegaSquadronPilot() : base()
             {
                 PilotName = "Omega Squadron Pilot";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/First%20Order/TIE-fo%20Fighter/omega-squadron-pilot.png";
                 PilotSkill = 4;
                 Cost = 17;
 

--- a/Assets/Scripts/Model/Ships/TIE FO/TIEFO.cs
+++ b/Assets/Scripts/Model/Ships/TIE FO/TIEFO.cs
@@ -31,8 +31,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = null;
 
-                factions.Add(Faction.Empire);
-                faction = Faction.Empire;
+                factions.Add(Faction.Imperial);
+                faction = Faction.Imperial;
 
                 SkinName = "First Order";
 

--- a/Assets/Scripts/Model/Ships/TIE FO/TIEFO.cs
+++ b/Assets/Scripts/Model/Ships/TIE FO/TIEFO.cs
@@ -22,6 +22,8 @@ namespace Ship
                 MaxHull = 3;
                 MaxShields = 1;
 
+                SubFaction = SubFaction.FirstOrder;
+
                 PrintedUpgradeIcons.Add(Upgrade.UpgradeType.Tech);
 
                 PrintedActions.Add(new TargetLockAction());

--- a/Assets/Scripts/Model/Ships/TIE FO/ZetaLeader.cs
+++ b/Assets/Scripts/Model/Ships/TIE FO/ZetaLeader.cs
@@ -12,7 +12,6 @@ namespace Ship
             public ZetaLeader () : base ()
             {
                 PilotName = "Zeta Leader";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/First%20Order/TIE-fo%20Fighter/zeta-leader.png";
                 PilotSkill = 7;
                 Cost = 20;
 

--- a/Assets/Scripts/Model/Ships/TIE FO/ZetaSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE FO/ZetaSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public ZetaSquadronPilot() : base()
             {
                 PilotName = "Zeta Squadron Pilot";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/First%20Order/TIE-fo%20Fighter/zeta-squadron-pilot.png";
                 PilotSkill = 3;
                 Cost = 16;
 

--- a/Assets/Scripts/Model/Ships/TIE Fighter/AcademyPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE Fighter/AcademyPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public AcademyPilot() : base()
             {
                 PilotName = "Academy Pilot";
-                ImageUrl = "https://vignette2.wikia.nocookie.net/xwing-miniatures/images/4/41/Academy-pilot.png";
                 PilotSkill = 1;
                 Cost = 12;
             }

--- a/Assets/Scripts/Model/Ships/TIE Fighter/Backstabber.cs
+++ b/Assets/Scripts/Model/Ships/TIE Fighter/Backstabber.cs
@@ -11,7 +11,6 @@ namespace Ship
             public Backstabber() : base()
             {
                 PilotName = "\"Backstabber\"";
-                ImageUrl = "https://vignette3.wikia.nocookie.net/xwing-miniatures/images/5/52/Backstabber.png";
                 PilotSkill = 6;
                 Cost = 16;
 

--- a/Assets/Scripts/Model/Ships/TIE Fighter/BlackSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE Fighter/BlackSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public BlackSquadronPilot() : base()
             {
                 PilotName = "Black Squadron Pilot";
-                ImageUrl = "https://vignette3.wikia.nocookie.net/xwing-miniatures/images/b/b2/Black_Squadron_Pilot.jpg";
                 PilotSkill = 4;
                 Cost = 14;
                 PrintedUpgradeIcons.Add(Upgrade.UpgradeType.Elite);

--- a/Assets/Scripts/Model/Ships/TIE Fighter/DarkCurse.cs
+++ b/Assets/Scripts/Model/Ships/TIE Fighter/DarkCurse.cs
@@ -11,7 +11,6 @@ namespace Ship
             public DarkCurse() : base()
             {
                 PilotName = "\"Dark Curse\"";
-                ImageUrl = "https://vignette1.wikia.nocookie.net/xwing-miniatures/images/4/49/Dark_Curse.png";
                 PilotSkill = 6;
                 Cost = 16;
 

--- a/Assets/Scripts/Model/Ships/TIE Fighter/Howlrunner.cs
+++ b/Assets/Scripts/Model/Ships/TIE Fighter/Howlrunner.cs
@@ -13,7 +13,6 @@ namespace Ship
             public Howlrunner() : base()
             {
                 PilotName = "\"Howlrunner\"";
-                ImageUrl = "https://vignette4.wikia.nocookie.net/xwing-miniatures/images/7/71/Howlrunner.png";
                 PilotSkill = 8;
                 Cost = 18;
 

--- a/Assets/Scripts/Model/Ships/TIE Fighter/MaulerMithel.cs
+++ b/Assets/Scripts/Model/Ships/TIE Fighter/MaulerMithel.cs
@@ -11,7 +11,6 @@ namespace Ship
             public MaulerMithel() : base()
             {
                 PilotName = "\"Mauler Mithel\"";
-                ImageUrl = "https://vignette2.wikia.nocookie.net/xwing-miniatures/images/e/e8/Mauler-mithel.png";
                 PilotSkill = 7;
                 Cost = 17;
 

--- a/Assets/Scripts/Model/Ships/TIE Fighter/NightBeast.cs
+++ b/Assets/Scripts/Model/Ships/TIE Fighter/NightBeast.cs
@@ -12,7 +12,6 @@ namespace Ship
             public NightBeast() : base()
             {
                 PilotName = "\"Night Beast\"";
-                ImageUrl = "https://vignette2.wikia.nocookie.net/xwing-miniatures/images/b/ba/Night_Beast.png";
                 PilotSkill = 5;
                 Cost = 15;
 

--- a/Assets/Scripts/Model/Ships/TIE Fighter/ObsidianSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE Fighter/ObsidianSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public ObsidianSquadronPilot() : base()
             {
                 PilotName = "Obsidian Squadron Pilot";
-                ImageUrl = "https://vignette3.wikia.nocookie.net/xwing-miniatures/images/e/ef/Obsidian-squadron-pilot.png";
                 PilotSkill = 3;
                 Cost = 13;
             }

--- a/Assets/Scripts/Model/Ships/TIE Fighter/TIEFighter.cs
+++ b/Assets/Scripts/Model/Ships/TIE Fighter/TIEFighter.cs
@@ -28,9 +28,9 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = new AI.TIEFighterTable();
 
-                factions.Add(Faction.Empire);
-                factions.Add(Faction.Rebels);
-                faction = Faction.Empire;
+                factions.Add(Faction.Imperial);
+                factions.Add(Faction.Rebel);
+                faction = Faction.Imperial;
 
                 SkinName = "Gray";
 

--- a/Assets/Scripts/Model/Ships/TIE Fighter/WingedGundark.cs
+++ b/Assets/Scripts/Model/Ships/TIE Fighter/WingedGundark.cs
@@ -12,7 +12,6 @@ namespace Ship
             public WingedGundark() : base()
             {
                 PilotName = "\"Winged Gundark\"";
-                ImageUrl = "https://vignette2.wikia.nocookie.net/xwing-miniatures/images/9/9d/Winged-gundark.png";
                 PilotSkill = 5;
                 Cost = 15;
 

--- a/Assets/Scripts/Model/Ships/TIE Fighter/ZebOrrelios.cs
+++ b/Assets/Scripts/Model/Ships/TIE Fighter/ZebOrrelios.cs
@@ -15,7 +15,7 @@ namespace Ship
                 PilotSkill = 4;
                 Cost = 14;
 
-                faction = Faction.Rebels;
+                faction = Faction.Rebel;
             }
         }
     }

--- a/Assets/Scripts/Model/Ships/TIE Fighter/ZebOrrelios.cs
+++ b/Assets/Scripts/Model/Ships/TIE Fighter/ZebOrrelios.cs
@@ -11,7 +11,6 @@ namespace Ship
             public ZebOrrelios() : base()
             {
                 PilotName = "Rebel TIE Generic";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Rebel%20Alliance/TIE%20Fighter/zeb-orrelios.png";
                 PilotSkill = 4;
                 Cost = 14;
 

--- a/Assets/Scripts/Model/Ships/TIE Interceptor/AlphaSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE Interceptor/AlphaSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public AlphaSquadronPilot() : base()
             {
                 PilotName = "Alpha Squadron Pilot";
-                ImageUrl = "https://vignette4.wikia.nocookie.net/xwing-miniatures/images/c/c2/Alpha_Squadron_Pilot.png";
                 PilotSkill = 1;
                 Cost = 18;
             }

--- a/Assets/Scripts/Model/Ships/TIE Interceptor/AvengerSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE Interceptor/AvengerSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public AvengerSquadronPilot() : base()
             {
                 PilotName = "Avenger Squadron Pilot";
-                ImageUrl = "https://vignette3.wikia.nocookie.net/xwing-miniatures/images/5/50/Avenger_Squadron_Pilot.png";
                 PilotSkill = 3;
                 Cost = 20;
             }

--- a/Assets/Scripts/Model/Ships/TIE Interceptor/FelsWrath.cs
+++ b/Assets/Scripts/Model/Ships/TIE Interceptor/FelsWrath.cs
@@ -12,7 +12,6 @@ namespace Ship
             public FelsWrath()
             {
                 PilotName = "\"Fel's Wrath\"";
-                ImageUrl = "https://vignette.wikia.nocookie.net/xwing-miniatures/images/1/12/Fel%27s_Wrath.png";
                 PilotSkill = 5;
                 Cost = 23;
 

--- a/Assets/Scripts/Model/Ships/TIE Interceptor/RoyalGuardPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE Interceptor/RoyalGuardPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public RoyalGuardPilot() : base()
             {
                 PilotName = "Royal Guard Pilot";
-                ImageUrl = "https://vignette1.wikia.nocookie.net/xwing-miniatures/images/d/d0/Royal_Guard_TIE.png";
                 PilotSkill = 6;
                 Cost = 22;
 

--- a/Assets/Scripts/Model/Ships/TIE Interceptor/SaberSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE Interceptor/SaberSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public SaberSquadronPilot() : base()
             {
                 PilotName = "Saber Squadron Pilot";
-                ImageUrl = "https://vignette1.wikia.nocookie.net/xwing-miniatures/images/5/5f/Saber_Squadron_Pilot.png";
                 PilotSkill = 4;
                 Cost = 21;
 

--- a/Assets/Scripts/Model/Ships/TIE Interceptor/SoontirFel.cs
+++ b/Assets/Scripts/Model/Ships/TIE Interceptor/SoontirFel.cs
@@ -14,7 +14,6 @@ namespace Ship
             public SoontirFel() : base()
             {
                 PilotName = "Soontir Fel";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/TIE%20Interceptor/soontir-fel.png";
                 PilotSkill = 9;
                 Cost = 27;
 

--- a/Assets/Scripts/Model/Ships/TIE Interceptor/TIEInterceptor.cs
+++ b/Assets/Scripts/Model/Ships/TIE Interceptor/TIEInterceptor.cs
@@ -29,8 +29,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = new AI.TIEInterceptorTable();
 
-                factions.Add(Faction.Empire);
-                faction = Faction.Empire;
+                factions.Add(Faction.Imperial);
+                faction = Faction.Imperial;
 
                 SkinName = "Blue";
 

--- a/Assets/Scripts/Model/Ships/TIE Interceptor/TurrPhennir.cs
+++ b/Assets/Scripts/Model/Ships/TIE Interceptor/TurrPhennir.cs
@@ -12,7 +12,6 @@ namespace Ship
             public TurrPhennir() : base()
             {
                 PilotName = "Turr Phennir";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/TIE%20Interceptor/turr-phennir.png";
                 PilotSkill = 7;
                 Cost = 25;
 

--- a/Assets/Scripts/Model/Ships/TIE Phantom/ShadowSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE Phantom/ShadowSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public ShadowSquadronPilot() : base()
             {
                 PilotName = "Shadow Squadron Pilot";
-                ImageUrl = "https://vignette2.wikia.nocookie.net/xwing-miniatures/images/0/0d/Shadow-squadron-pilot.png";
                 PilotSkill = 5;
                 Cost = 27;
             }

--- a/Assets/Scripts/Model/Ships/TIE Phantom/SigmaSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE Phantom/SigmaSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public SigmaSquadronPilot() : base()
             {
                 PilotName = "Sigma Squadron Pilot";
-                ImageUrl = "https://vignette2.wikia.nocookie.net/xwing-miniatures/images/d/d8/Sigma-squadron-pilot.png";
                 PilotSkill = 3;
                 Cost = 25;
             }

--- a/Assets/Scripts/Model/Ships/TIE Phantom/TIEPhantom.cs
+++ b/Assets/Scripts/Model/Ships/TIE Phantom/TIEPhantom.cs
@@ -32,8 +32,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = new AI.TIEPhantomTable();
 
-                factions.Add(Faction.Empire);
-                faction = Faction.Empire;
+                factions.Add(Faction.Imperial);
+                faction = Faction.Imperial;
 
                 SkinName = "Gray";
 

--- a/Assets/Scripts/Model/Ships/TIE Phantom/Whisper.cs
+++ b/Assets/Scripts/Model/Ships/TIE Phantom/Whisper.cs
@@ -13,7 +13,6 @@ namespace Ship
             public Whisper() : base()
             {
                 PilotName = "\"Whisper\"";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/TIE%20Phantom/whisper.png";
                 PilotSkill = 7;
                 Cost = 32;
 

--- a/Assets/Scripts/Model/Ships/TIE Punisher/BlackEightSqPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE Punisher/BlackEightSqPilot.cs
@@ -11,7 +11,7 @@ namespace Ship
             public BlackEightSqPilot() : base()
             {
                 PilotName = "Black Eight Sq. Pilot";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/TIE%20Punisher/black-eight-squadron-pilot.png";
+                ImageUrl = ImageUrls.GetImageUrl(this, "black-eight-squadron-pilot.png");
                 PilotSkill = 4;
                 Cost = 23;
             }

--- a/Assets/Scripts/Model/Ships/TIE Punisher/CutlassSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/TIE Punisher/CutlassSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public CutlassSquadronPilot() : base()
             {
                 PilotName = "Cutlass Squadron Pilot";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/TIE%20Punisher/cutlass-squadron-pilot.png";
                 PilotSkill = 2;
                 Cost = 21;
             }

--- a/Assets/Scripts/Model/Ships/TIE Punisher/TIE Punisher.cs
+++ b/Assets/Scripts/Model/Ships/TIE Punisher/TIE Punisher.cs
@@ -36,8 +36,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = null;
 
-                factions.Add(Faction.Empire);
-                faction = Faction.Empire;
+                factions.Add(Faction.Imperial);
+                faction = Faction.Imperial;
 
                 SkinName = "Blue";
 

--- a/Assets/Scripts/Model/Ships/TIE SF/OmegaSpecialist.cs
+++ b/Assets/Scripts/Model/Ships/TIE SF/OmegaSpecialist.cs
@@ -11,7 +11,6 @@ namespace Ship
             public OmegaSpecialist() : base()
             {
                 PilotName = "Omega Specialist";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/First%20Order/TIE-sf%20Fighter/omega-specialist.png";
                 PilotSkill = 5;
                 Cost = 25;
 

--- a/Assets/Scripts/Model/Ships/TIE SF/TIESF.cs
+++ b/Assets/Scripts/Model/Ships/TIE SF/TIESF.cs
@@ -24,6 +24,8 @@ namespace Ship
                 MaxHull = 3;
                 MaxShields = 3;
 
+                SubFaction = SubFaction.FirstOrder;
+
                 PrintedUpgradeIcons.Add(Upgrade.UpgradeType.System);
                 PrintedUpgradeIcons.Add(Upgrade.UpgradeType.Missile);
                 PrintedUpgradeIcons.Add(Upgrade.UpgradeType.Tech);

--- a/Assets/Scripts/Model/Ships/TIE SF/TIESF.cs
+++ b/Assets/Scripts/Model/Ships/TIE SF/TIESF.cs
@@ -34,8 +34,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = null;
 
-                factions.Add(Faction.Empire);
-                faction = Faction.Empire;
+                factions.Add(Faction.Imperial);
+                faction = Faction.Imperial;
 
                 SkinName = "First Order";
 

--- a/Assets/Scripts/Model/Ships/TIE SF/ZetaSpecialist.cs
+++ b/Assets/Scripts/Model/Ships/TIE SF/ZetaSpecialist.cs
@@ -11,7 +11,6 @@ namespace Ship
             public ZetaSpecialist() : base()
             {
                 PilotName = "Zeta Specialist";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/First%20Order/TIE-sf%20Fighter/zeta-specialist.png";
                 PilotSkill = 3;
                 Cost = 23;
             }

--- a/Assets/Scripts/Model/Ships/TIE Striker/BlackSquadronScout.cs
+++ b/Assets/Scripts/Model/Ships/TIE Striker/BlackSquadronScout.cs
@@ -11,7 +11,6 @@ namespace Ship
             public BlackSquadronScout() : base()
             {
                 PilotName = "Black Squadron Scout";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/TIE%20Striker/black-squadron-scout.png";
                 PilotSkill = 4;
                 Cost = 20;
 

--- a/Assets/Scripts/Model/Ships/TIE Striker/ImperialTrainee.cs
+++ b/Assets/Scripts/Model/Ships/TIE Striker/ImperialTrainee.cs
@@ -11,7 +11,6 @@ namespace Ship
             public ImperialTrainee() : base()
             {
                 PilotName = "Imperial Trainee";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/TIE%20Striker/imperial-trainee.png";
                 PilotSkill = 1;
                 Cost = 17;
             }

--- a/Assets/Scripts/Model/Ships/TIE Striker/ScarifDefender.cs
+++ b/Assets/Scripts/Model/Ships/TIE Striker/ScarifDefender.cs
@@ -11,7 +11,6 @@ namespace Ship
             public ScarifDefender() : base()
             {
                 PilotName = "Scarif Defender";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/TIE%20Striker/scarif-defender.png";
                 PilotSkill = 3;
                 Cost = 18;
             }

--- a/Assets/Scripts/Model/Ships/TIE Striker/TIEStriker.cs
+++ b/Assets/Scripts/Model/Ships/TIE Striker/TIEStriker.cs
@@ -28,8 +28,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = null;
 
-                factions.Add(Faction.Empire);
-                faction = Faction.Empire;
+                factions.Add(Faction.Imperial);
+                faction = Faction.Imperial;
 
                 SkinName = "Gray";
 

--- a/Assets/Scripts/Model/Ships/U-Wing/BlueSquadronPathfinder.cs
+++ b/Assets/Scripts/Model/Ships/U-Wing/BlueSquadronPathfinder.cs
@@ -11,7 +11,6 @@ namespace Ship
             public BlueSquadronPathfinder() : base()
             {
                 PilotName = "Blue Squadron Pathfinder";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Rebel%20Alliance/U-wing/blue-squadron-pathfinder.png";
                 PilotSkill = 2;
                 Cost = 23;
             }

--- a/Assets/Scripts/Model/Ships/U-Wing/UWing.cs
+++ b/Assets/Scripts/Model/Ships/U-Wing/UWing.cs
@@ -33,8 +33,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = null;
 
-                factions.Add(Faction.Rebels);
-                faction = Faction.Rebels;
+                factions.Add(Faction.Rebel);
+                faction = Faction.Rebel;
 
                 SkinName = "White";
 

--- a/Assets/Scripts/Model/Ships/UpsilonShuttle/StarkillerBasePilot.cs
+++ b/Assets/Scripts/Model/Ships/UpsilonShuttle/StarkillerBasePilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public StarkillerBasePilot() : base()
             {
                 PilotName = "Starkiller Base Pilot";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/First%20Order/Upsilon-class%20Shuttle/starkiller-base-pilot.png";
                 PilotSkill = 2;
                 Cost = 30;
             }

--- a/Assets/Scripts/Model/Ships/UpsilonShuttle/UpsilonShuttle.cs
+++ b/Assets/Scripts/Model/Ships/UpsilonShuttle/UpsilonShuttle.cs
@@ -23,6 +23,8 @@ namespace Ship
                 MaxHull = 6;
                 MaxShields = 6;
 
+                SubFaction = SubFaction.FirstOrder;
+
                 PrintedUpgradeIcons.Add(Upgrade.UpgradeType.System);
                 PrintedUpgradeIcons.Add(Upgrade.UpgradeType.Crew);
                 PrintedUpgradeIcons.Add(Upgrade.UpgradeType.Crew);

--- a/Assets/Scripts/Model/Ships/UpsilonShuttle/UpsilonShuttle.cs
+++ b/Assets/Scripts/Model/Ships/UpsilonShuttle/UpsilonShuttle.cs
@@ -34,8 +34,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = null;
 
-                factions.Add(Faction.Empire);
-                faction = Faction.Empire;
+                factions.Add(Faction.Imperial);
+                faction = Faction.Imperial;
 
                 SkinName = "Upsilon-class Shuttle";
 

--- a/Assets/Scripts/Model/Ships/VCX-100/LothalRebel.cs
+++ b/Assets/Scripts/Model/Ships/VCX-100/LothalRebel.cs
@@ -11,7 +11,6 @@ namespace Ship
             public LothalRebel() : base()
             {
                 PilotName = "Lothal Rebel";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Rebel%20Alliance/VCX-100/lothal-rebel.png";
                 PilotSkill = 3;
                 Cost = 35;
             }

--- a/Assets/Scripts/Model/Ships/VCX-100/Vcx100.cs
+++ b/Assets/Scripts/Model/Ships/VCX-100/Vcx100.cs
@@ -37,8 +37,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = null;
 
-                factions.Add(Faction.Rebels);
-                faction = Faction.Rebels;
+                factions.Add(Faction.Rebel);
+                faction = Faction.Rebel;
 
                 SkinName = "VCX-100";
 

--- a/Assets/Scripts/Model/Ships/VT-49 Decimator/PatrolLeader.cs
+++ b/Assets/Scripts/Model/Ships/VT-49 Decimator/PatrolLeader.cs
@@ -11,7 +11,6 @@ namespace Ship
             public PatrolLeader() : base()
             {
                 PilotName = "Patrol Leader";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Galactic%20Empire/VT-49%20Decimator/patrol-leader.png";
                 PilotSkill = 3;
                 Cost = 40;
             }

--- a/Assets/Scripts/Model/Ships/VT-49 Decimator/VT49Decimator.cs
+++ b/Assets/Scripts/Model/Ships/VT-49 Decimator/VT49Decimator.cs
@@ -35,8 +35,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = new AI.VT49DecimatorTable();
 
-                factions.Add(Faction.Empire);
-                faction = Faction.Empire;
+                factions.Add(Faction.Imperial);
+                faction = Faction.Imperial;
 
                 SkinName = "Gray";
 

--- a/Assets/Scripts/Model/Ships/X-Wing/BiggsDarklighter.cs
+++ b/Assets/Scripts/Model/Ships/X-Wing/BiggsDarklighter.cs
@@ -12,7 +12,6 @@ namespace Ship
             public BiggsDarklighter() : base()
             {
                 PilotName = "Biggs Darklighter";
-                ImageUrl = "https://vignette3.wikia.nocookie.net/xwing-miniatures/images/9/90/Biggs-darklighter.png";
                 PilotSkill = 5;
                 Cost = 25;
 

--- a/Assets/Scripts/Model/Ships/X-Wing/GarvenDreis.cs
+++ b/Assets/Scripts/Model/Ships/X-Wing/GarvenDreis.cs
@@ -13,7 +13,6 @@ namespace Ship
             public GarvenDreis() : base()
             {
                 PilotName = "Garven Dreis";
-                ImageUrl = "https://vignette3.wikia.nocookie.net/xwing-miniatures/images/f/f8/Garven-dreis.png";
                 PilotSkill = 6;
                 Cost = 26;
 

--- a/Assets/Scripts/Model/Ships/X-Wing/LukeSkywalker.cs
+++ b/Assets/Scripts/Model/Ships/X-Wing/LukeSkywalker.cs
@@ -12,7 +12,6 @@ namespace Ship
             public LukeSkywalker() : base()
             {
                 PilotName = "Luke Skywalker";
-                ImageUrl = "https://vignette3.wikia.nocookie.net/xwing-miniatures/images/8/8c/Luke-skywalker.png";
                 PilotSkill = 8;
                 Cost = 28;
 

--- a/Assets/Scripts/Model/Ships/X-Wing/RedSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/X-Wing/RedSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public RedSquadronPilot() : base()
             {
                 PilotName = "Red Squadron Pilot";
-                ImageUrl = "https://vignette4.wikia.nocookie.net/xwing-miniatures/images/3/39/Red-squadron-pilot.png";
                 PilotSkill = 4;
                 Cost = 23;
             }

--- a/Assets/Scripts/Model/Ships/X-Wing/RookiePilot.cs
+++ b/Assets/Scripts/Model/Ships/X-Wing/RookiePilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public RookiePilot() : base()
             {
                 PilotName = "Rookie Pilot";
-                ImageUrl = "https://vignette1.wikia.nocookie.net/xwing-miniatures/images/c/cc/Rookie-pilot.png";
                 PilotSkill = 2;
                 Cost = 21;
             }

--- a/Assets/Scripts/Model/Ships/X-Wing/WedgeAntilles.cs
+++ b/Assets/Scripts/Model/Ships/X-Wing/WedgeAntilles.cs
@@ -12,7 +12,6 @@ namespace Ship
             public WedgeAntilles() : base()
             {
                 PilotName = "Wedge Antilles";
-                ImageUrl = "https://vignette2.wikia.nocookie.net/xwing-miniatures/images/8/80/Wedge-antilles.png";
                 PilotSkill = 9;
                 Cost = 29;
 

--- a/Assets/Scripts/Model/Ships/X-Wing/XWing.cs
+++ b/Assets/Scripts/Model/Ships/X-Wing/XWing.cs
@@ -30,8 +30,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = new AI.XWingTable();
 
-                factions.Add(Faction.Rebels);
-                faction = Faction.Rebels;
+                factions.Add(Faction.Rebel);
+                faction = Faction.Rebel;
 
                 SkinName = "Red";
 

--- a/Assets/Scripts/Model/Ships/Y-Wing/DutchVander.cs
+++ b/Assets/Scripts/Model/Ships/Y-Wing/DutchVander.cs
@@ -13,7 +13,6 @@ namespace Ship
             public DutchVander() : base()
             {
                 PilotName = "\"Dutch\" Vander";
-                ImageUrl = "https://vignette3.wikia.nocookie.net/xwing-miniatures/images/b/bf/Dutch_Vander.png";
                 PilotSkill = 6;
                 Cost = 23;
 

--- a/Assets/Scripts/Model/Ships/Y-Wing/DutchVander.cs
+++ b/Assets/Scripts/Model/Ships/Y-Wing/DutchVander.cs
@@ -21,7 +21,7 @@ namespace Ship
 
                 PrintedUpgradeIcons.Add(Upgrade.UpgradeType.Astromech);
 
-                faction = Faction.Rebels;
+                faction = Faction.Rebel;
 
                 PilotAbilities.Add(new PilotAbilitiesNamespace.DutchVanderAbility());
             }

--- a/Assets/Scripts/Model/Ships/Y-Wing/GoldSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/Y-Wing/GoldSquadronPilot.cs
@@ -17,7 +17,7 @@ namespace Ship
 
                 PrintedUpgradeIcons.Add(Upgrade.UpgradeType.Astromech);
 
-                faction = Faction.Rebels;
+                faction = Faction.Rebel;
             }
         }
     }

--- a/Assets/Scripts/Model/Ships/Y-Wing/GoldSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/Y-Wing/GoldSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public GoldSquadronPilot() : base()
             {
                 PilotName = "Gold Squadron Pilot";
-                ImageUrl = "https://vignette2.wikia.nocookie.net/xwing-miniatures/images/d/d7/Gold_Squadron_Pilot.jpg";
                 PilotSkill = 2;
                 Cost = 18;
 

--- a/Assets/Scripts/Model/Ships/Y-Wing/GraySquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/Y-Wing/GraySquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public GraySquadronPilot() : base()
             {
                 PilotName = "Gray Squadron Pilot";
-                ImageUrl = "https://vignette3.wikia.nocookie.net/xwing-miniatures/images/c/ca/Grey_Squadron_Pilot.jpg";
                 PilotSkill = 4;
                 Cost = 20;
 

--- a/Assets/Scripts/Model/Ships/Y-Wing/GraySquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/Y-Wing/GraySquadronPilot.cs
@@ -19,7 +19,7 @@ namespace Ship
 
                 SkinName = "Gray";
 
-                faction = Faction.Rebels;
+                faction = Faction.Rebel;
             }
         }
     }

--- a/Assets/Scripts/Model/Ships/Y-Wing/HiredGun.cs
+++ b/Assets/Scripts/Model/Ships/Y-Wing/HiredGun.cs
@@ -11,7 +11,6 @@ namespace Ship
             public HiredGun() : base()
             {
                 PilotName = "Hired Gun";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/Y-wing/hired-gun.png";
                 PilotSkill = 4;
                 Cost = 20;
 

--- a/Assets/Scripts/Model/Ships/Y-Wing/HortonSalm.cs
+++ b/Assets/Scripts/Model/Ships/Y-Wing/HortonSalm.cs
@@ -20,7 +20,7 @@ namespace Ship
 
                 PrintedUpgradeIcons.Add(Upgrade.UpgradeType.Astromech);
 
-                faction = Faction.Rebels;
+                faction = Faction.Rebel;
 
                 SkinName = "Gray";
 

--- a/Assets/Scripts/Model/Ships/Y-Wing/HortonSalm.cs
+++ b/Assets/Scripts/Model/Ships/Y-Wing/HortonSalm.cs
@@ -12,7 +12,6 @@ namespace Ship
             public HortonSalm() : base()
             {
                 PilotName = "Horton Salm";
-                ImageUrl = "https://vignette4.wikia.nocookie.net/xwing-miniatures/images/5/56/Horton_Salm.png";
                 PilotSkill = 8;
                 Cost = 25;
 

--- a/Assets/Scripts/Model/Ships/Y-Wing/SyndicateThug.cs
+++ b/Assets/Scripts/Model/Ships/Y-Wing/SyndicateThug.cs
@@ -11,7 +11,6 @@ namespace Ship
             public SyndicateThug() : base()
             {
                 PilotName = "Syndicate Thug";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/Y-wing/syndicate-thug.png";
                 PilotSkill = 2;
                 Cost = 18;
 

--- a/Assets/Scripts/Model/Ships/Y-Wing/YWing.cs
+++ b/Assets/Scripts/Model/Ships/Y-Wing/YWing.cs
@@ -31,7 +31,7 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = new AI.YWingTable();
 
-                factions.Add(Faction.Rebels);
+                factions.Add(Faction.Rebel);
                 factions.Add(Faction.Scum);
 
                 SkinName = "Yellow";

--- a/Assets/Scripts/Model/Ships/YT-1300/Chewbacca.cs
+++ b/Assets/Scripts/Model/Ships/YT-1300/Chewbacca.cs
@@ -11,7 +11,6 @@ namespace Ship
             public Chewbacca() : base()
             {
                 PilotName = "Chewbacca";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Rebel%20Alliance/YT-1300/chewbacca.png";
                 PilotSkill = 5;
                 Cost = 42;
 

--- a/Assets/Scripts/Model/Ships/YT-1300/HanSolo.cs
+++ b/Assets/Scripts/Model/Ships/YT-1300/HanSolo.cs
@@ -13,7 +13,6 @@ namespace Ship
             public HanSolo() : base()
             {
                 PilotName = "Han Solo";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Rebel%20Alliance/YT-1300/han-solo.png";
                 PilotSkill = 9;
                 Cost = 46;
 

--- a/Assets/Scripts/Model/Ships/YT-1300/LandoCalrissian.cs
+++ b/Assets/Scripts/Model/Ships/YT-1300/LandoCalrissian.cs
@@ -13,7 +13,6 @@ namespace Ship
             public LandoCalrissian() : base()
             {
                 PilotName = "Lando Calrissian";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Rebel%20Alliance/YT-1300/lando-calrissian.png";
                 PilotSkill = 7;
                 Cost = 44;
 

--- a/Assets/Scripts/Model/Ships/YT-1300/OuterRimSmuggler.cs
+++ b/Assets/Scripts/Model/Ships/YT-1300/OuterRimSmuggler.cs
@@ -11,7 +11,6 @@ namespace Ship
             public OuterRimSmuggler() : base()
             {
                 PilotName = "Outer Rim Smuggler";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Rebel%20Alliance/YT-1300/outer-rim-smuggler.png";
                 PilotSkill = 1;
                 Cost = 27;
             }

--- a/Assets/Scripts/Model/Ships/YT-1300/Rey.cs
+++ b/Assets/Scripts/Model/Ships/YT-1300/Rey.cs
@@ -23,6 +23,8 @@ namespace Ship
                 MaxHull = 8;
                 MaxShields = 5;
 
+                SubFaction = SubFaction.FirstOrder;
+
                 PrintedUpgradeIcons.Add(Upgrade.UpgradeType.Missile);
                 PrintedUpgradeIcons.Add(Upgrade.UpgradeType.Elite);
 

--- a/Assets/Scripts/Model/Ships/YT-1300/Yt-1300.cs
+++ b/Assets/Scripts/Model/Ships/YT-1300/Yt-1300.cs
@@ -32,8 +32,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = new AI.YT1300Table();
 
-                factions.Add(Faction.Rebels);
-                faction = Faction.Rebels;
+                factions.Add(Faction.Rebel);
+                faction = Faction.Rebel;
 
                 SkinName = "YT-1300";
 

--- a/Assets/Scripts/Model/Ships/YT-2400/DashRendar.cs
+++ b/Assets/Scripts/Model/Ships/YT-2400/DashRendar.cs
@@ -11,7 +11,6 @@ namespace Ship
             public DashRendar() : base()
             {
                 PilotName = "Dash Rendar";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Rebel%20Alliance/YT-2400/dash-rendar.png";
                 PilotSkill = 7;
                 Cost = 36;
 

--- a/Assets/Scripts/Model/Ships/YT-2400/WildSpaceFringer.cs
+++ b/Assets/Scripts/Model/Ships/YT-2400/WildSpaceFringer.cs
@@ -11,7 +11,6 @@ namespace Ship
             public WildSpaceFringer() : base()
             {
                 PilotName = "Wild Space Fringer";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Rebel%20Alliance/YT-2400/wild-space-fringer.png";
                 PilotSkill = 2;
                 Cost = 30;
             }

--- a/Assets/Scripts/Model/Ships/YT-2400/YT2400.cs
+++ b/Assets/Scripts/Model/Ships/YT-2400/YT2400.cs
@@ -34,8 +34,8 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = new AI.YT2400Table();
 
-                factions.Add(Faction.Rebels);
-                faction = Faction.Rebels;
+                factions.Add(Faction.Rebel);
+                faction = Faction.Rebel;
 
                 SkinName = "YT-2400";
 

--- a/Assets/Scripts/Model/Ships/YV-666/MoraloEval.cs
+++ b/Assets/Scripts/Model/Ships/YV-666/MoraloEval.cs
@@ -11,7 +11,6 @@ namespace Ship
             public MoraloEval() : base()
             {
                 PilotName = "Moralo Eval";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/YV-666/moralo-eval.png";
                 PilotSkill = 6;
                 Cost = 34;
 

--- a/Assets/Scripts/Model/Ships/YV-666/TrandoshanSlaver.cs
+++ b/Assets/Scripts/Model/Ships/YV-666/TrandoshanSlaver.cs
@@ -11,7 +11,6 @@ namespace Ship
             public TrandoshanSlaver() : base()
             {
                 PilotName = "Trandoshan Slaver";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/YV-666/trandoshan-slaver.png";
                 PilotSkill = 2;
                 Cost = 29;
             }

--- a/Assets/Scripts/Model/Ships/Z-95/BanditSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/Z-95/BanditSquadronPilot.cs
@@ -15,7 +15,7 @@ namespace Ship
                 PilotSkill = 2;
                 Cost = 12;
 
-                faction = Faction.Rebels;
+                faction = Faction.Rebel;
             }
         }
     }

--- a/Assets/Scripts/Model/Ships/Z-95/BanditSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/Z-95/BanditSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public BanditSquadronPilot() : base()
             {
                 PilotName = "Bandit Squadron Pilot";
-                ImageUrl = "https://vignette3.wikia.nocookie.net/xwing-miniatures/images/5/5d/Bandit-squadron-pilot.png";
                 PilotSkill = 2;
                 Cost = 12;
 

--- a/Assets/Scripts/Model/Ships/Z-95/BinayrePirate.cs
+++ b/Assets/Scripts/Model/Ships/Z-95/BinayrePirate.cs
@@ -11,7 +11,6 @@ namespace Ship
             public BinayrePirate() : base()
             {
                 PilotName = "Binayre Pirate";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/Z-95%20Headhunter/binayre-pirate.png";
                 PilotSkill = 1;
                 Cost = 12;
 

--- a/Assets/Scripts/Model/Ships/Z-95/BlackSunSoldier.cs
+++ b/Assets/Scripts/Model/Ships/Z-95/BlackSunSoldier.cs
@@ -11,7 +11,6 @@ namespace Ship
             public BlackSunSoldier() : base()
             {
                 PilotName = "Black Sun Soldier";
-                ImageUrl = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/pilots/Scum%20and%20Villainy/Z-95%20Headhunter/black-sun-soldier.png";
                 PilotSkill = 3;
                 Cost = 13;
 

--- a/Assets/Scripts/Model/Ships/Z-95/TalaSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/Z-95/TalaSquadronPilot.cs
@@ -15,7 +15,7 @@ namespace Ship
                 PilotSkill = 4;
                 Cost = 13;
 
-                faction = Faction.Rebels;
+                faction = Faction.Rebel;
             }
         }
     }

--- a/Assets/Scripts/Model/Ships/Z-95/TalaSquadronPilot.cs
+++ b/Assets/Scripts/Model/Ships/Z-95/TalaSquadronPilot.cs
@@ -11,7 +11,6 @@ namespace Ship
             public TalaSquadronPilot() : base()
             {
                 PilotName = "Tala Squadron Pilot";
-                ImageUrl = "http://vignette1.wikia.nocookie.net/xwing-miniatures/images/b/b0/Tala-squadron-pilot.png";
                 PilotSkill = 4;
                 Cost = 13;
 

--- a/Assets/Scripts/Model/Ships/Z-95/Z95.cs
+++ b/Assets/Scripts/Model/Ships/Z-95/Z95.cs
@@ -27,7 +27,7 @@ namespace Ship
                 AssignTemporaryManeuvers();
                 HotacManeuverTable = new AI.Z95Table();
 
-                factions.Add(Faction.Rebels);
+                factions.Add(Faction.Rebel);
                 factions.Add(Faction.Scum);
 
                 PrintedActions.Add(new TargetLockAction());

--- a/Assets/Scripts/Model/Upgrades/Crew/AgentKallus.cs
+++ b/Assets/Scripts/Model/Upgrades/Crew/AgentKallus.cs
@@ -19,7 +19,7 @@ namespace UpgradesList
 
         public override bool IsAllowedForShip(GenericShip ship)
         {
-            return ship.faction == Faction.Empire;
+            return ship.faction == Faction.Imperial;
         }
 
         public override void AttachToShip(GenericShip host)

--- a/Assets/Scripts/Model/Upgrades/Crew/Chewbacca.cs
+++ b/Assets/Scripts/Model/Upgrades/Crew/Chewbacca.cs
@@ -18,7 +18,7 @@ namespace UpgradesList
 
         public override bool IsAllowedForShip(GenericShip ship)
         {
-            return ship.faction == Faction.Rebels;
+            return ship.faction == Faction.Rebel;
         }
 
         public override void AttachToShip(GenericShip host)

--- a/Assets/Scripts/Model/Upgrades/Crew/Finn.cs
+++ b/Assets/Scripts/Model/Upgrades/Crew/Finn.cs
@@ -17,7 +17,7 @@ namespace UpgradesList
 
         public override bool IsAllowedForShip(GenericShip ship)
         {
-            return ship.faction == Faction.Rebels;
+            return ship.faction == Faction.Rebel;
         }
 
         public override void AttachToShip(GenericShip host)

--- a/Assets/Scripts/Model/Upgrades/Crew/KananJarrus.cs
+++ b/Assets/Scripts/Model/Upgrades/Crew/KananJarrus.cs
@@ -22,7 +22,7 @@ namespace UpgradesList
 
         public override bool IsAllowedForShip(GenericShip ship)
         {
-            return ship.faction == Faction.Rebels;
+            return ship.faction == Faction.Rebel;
         }
 
         public override void AttachToShip(GenericShip host)

--- a/Assets/Scripts/Model/Upgrades/Crew/LukeSkywalker.cs
+++ b/Assets/Scripts/Model/Upgrades/Crew/LukeSkywalker.cs
@@ -18,7 +18,7 @@ namespace UpgradesList
 
         public override bool IsAllowedForShip(GenericShip ship)
         {
-            return ship.faction == Faction.Rebels;
+            return ship.faction == Faction.Rebel;
         }
 
         public override void AttachToShip(GenericShip host)

--- a/Assets/Scripts/Model/Upgrades/Crew/NienNunb.cs
+++ b/Assets/Scripts/Model/Upgrades/Crew/NienNunb.cs
@@ -14,7 +14,7 @@ namespace UpgradesList
 
         public override bool IsAllowedForShip(Ship.GenericShip ship)
         {
-            return ship.faction == Faction.Rebels;
+            return ship.faction == Faction.Rebel;
         }
 
         public override void AttachToShip(Ship.GenericShip host)

--- a/Assets/Scripts/Model/Upgrades/Crew/RebelCaptive.cs
+++ b/Assets/Scripts/Model/Upgrades/Crew/RebelCaptive.cs
@@ -16,7 +16,7 @@ namespace UpgradesList
 
         public override bool IsAllowedForShip(Ship.GenericShip ship)
         {
-            return ship.faction == Faction.Empire;
+            return ship.faction == Faction.Imperial;
         }
 
         public override void AttachToShip(Ship.GenericShip host)

--- a/Assets/Scripts/Model/Upgrades/Elite/Selflessness.cs
+++ b/Assets/Scripts/Model/Upgrades/Elite/Selflessness.cs
@@ -23,7 +23,7 @@ namespace UpgradesList
             bool result = true;
 
             if (ship.ShipBaseSize != BaseSize.Small) result = false;
-            else if (ship.faction != Faction.Rebels) result = false;
+            else if (ship.faction != Faction.Rebel) result = false;
 
             return result;
         }


### PR DESCRIPTION
Added a subfaction property to GenericShip, that is used to get the correct image URL for pilot cards, so ImageUrl is not necessary to set anymore. Only necessary to set sub faction for Resistance and First Order pilots, as Rebel Alliance/Galactic Empire is default for their main faction.

Changed one ship for each sub faction to test the code. Will change the rest if you agree with how I've done this. 

I also changed the Faction enum to match the faction names in the rule book