### PR TITLE
Fix DeactivateAbility for DalanOberos, SoontirFel and TurrPhennir

### DIFF
--- a/Assets/Scripts/Model/Ships/M12-L Kimogila/DalanOberos.cs
+++ b/Assets/Scripts/Model/Ships/M12-L Kimogila/DalanOberos.cs
@@ -38,7 +38,7 @@ namespace PilotAbilitiesNamespace
 
         public override void DeactivateAbility()
         {
-            Phases.OnCombatPhaseStart += RegisterAbilityTrigger;
+            Phases.OnCombatPhaseStart -= RegisterAbilityTrigger;
         }
 
 

--- a/Assets/Scripts/Model/Ships/TIE Interceptor/SoontirFel.cs
+++ b/Assets/Scripts/Model/Ships/TIE Interceptor/SoontirFel.cs
@@ -41,7 +41,7 @@ namespace Abilities
 
         public override void DeactivateAbility()
         {
-            HostShip.OnTokenIsAssigned += RegisterSoontirFelAbility;
+            HostShip.OnTokenIsAssigned -= RegisterSoontirFelAbility;
         }
 
         private void RegisterSoontirFelAbility(GenericShip ship, System.Type tokenType)

--- a/Assets/Scripts/Model/Ships/TIE Interceptor/TurrPhennir.cs
+++ b/Assets/Scripts/Model/Ships/TIE Interceptor/TurrPhennir.cs
@@ -39,7 +39,7 @@ namespace Abilities
 
         public override void DeactivateAbility()
         {
-            HostShip.OnAttackFinish += RegisterTurrPhennirPilotAbility;
+            HostShip.OnAttackFinish -= RegisterTurrPhennirPilotAbility;
         }
 
         private void RegisterTurrPhennirPilotAbility(GenericShip ship)


### PR DESCRIPTION
Abiliy was added to the event on deactivation.
This is not critical as ship is usually destroyed and this is not a static event.
Such typo are critical if the ability uses static event (called for all ships), like Biggs/Howlrunner.