### PR TITLE
Fix "Skip" boost action.

### DIFF
--- a/Assets/Scripts/Model/Actions/ActionsList/BoostAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/BoostAction.cs
@@ -182,6 +182,8 @@ namespace SubPhases
         public void CancelBoost()
         {
             Selection.ThisShip.IsLandedOnObstacle = false;
+
+            Selection.ThisShip.RemoveAlreadyExecutedAction(typeof(ActionsList.BoostAction));
             MonoBehaviour.Destroy(ShipStand);
 
             GameManagerScript Game = GameObject.Find("GameManager").GetComponent<GameManagerScript>();


### PR DESCRIPTION
The action was not removed from the list "ActionAlreadyPerformed" if the use selected the boost action but skipped it while in "Selection Direction".