### PR TITLE
Minor fixes for upgrades/pilots. Added Obsolete tag on AttachToShip

### DIFF
--- a/Assets/Scripts/Model/Ships/Aggressor/Aggressor.cs
+++ b/Assets/Scripts/Model/Ships/Aggressor/Aggressor.cs
@@ -32,7 +32,7 @@ namespace Ship
                 PrintedUpgradeIcons.Add(Upgrade.UpgradeType.Illicit);
 
                 PrintedActions.Add(new TargetLockAction());
-                PrintedActions.Add(new BarrelRollAction());
+                PrintedActions.Add(new EvadeAction());
                 PrintedActions.Add(new BoostAction());
 
                 AssignTemporaryManeuvers();

--- a/Assets/Scripts/Model/Ships/HWK-290/KyleKatarn.cs
+++ b/Assets/Scripts/Model/Ships/HWK-290/KyleKatarn.cs
@@ -50,6 +50,8 @@ namespace Abilities
         {
             if (HostShip.Owner.Ships.Count > 1 && HostShip.HasToken(typeof(Tokens.FocusToken)))
             {
+                Messages.ShowInfoToHuman("Kyle Katarn: Select a ship to receive a Focus token");
+
                 SelectTargetForAbility(
                     SelectAbilityTarget,
                     new List<TargetTypes> { TargetTypes.OtherFriendly },

--- a/Assets/Scripts/Model/Ships/LambdaShuttle/ColonelJendon.cs
+++ b/Assets/Scripts/Model/Ships/LambdaShuttle/ColonelJendon.cs
@@ -68,6 +68,7 @@ namespace Abilities
                 });
 
                 pilotAbilityDecision.DefaultDecision = "No";
+                pilotAbilityDecision.RequiredPlayer = HostShip.Owner.PlayerNo;
 
                 pilotAbilityDecision.Start();
             }

--- a/Assets/Scripts/Model/Upgrades/GenericUpgrade.cs
+++ b/Assets/Scripts/Model/Upgrades/GenericUpgrade.cs
@@ -106,6 +106,7 @@ namespace Upgrade
 
         // ATTACH TO SHIP
 
+        [Obsolete("This is in the process of being depricated, please use new template instead: UpgradeAbilities.Add();", false)]
         public virtual void AttachToShip(Ship.GenericShip host)
         {
             Host = host;


### PR DESCRIPTION
Fixes:
     -KyleKatarn(Crew): Displays a message to the player about assigning focus tokens
     -Aggressor: Changed the Boost action to Evade
     -Colonel Jendon: The ability has a required player when being registered
     -Flechette Torpedo: Uses the new upgrade template(UpgradeAbilities.Add()), instead of AttachToShip

-Added a warning message for all instances of AttachToShip, informing all new cases that this functionality is to be deprecated.