### PR TITLE
Resolve interaction between BB8 and Push the Limit.

### DIFF
--- a/Assets/Scripts/Model/Upgrades/Elite/PushTheLimit.cs
+++ b/Assets/Scripts/Model/Upgrades/Elite/PushTheLimit.cs
@@ -10,6 +10,7 @@ namespace UpgradesList
 	public class PushTheLimit : GenericUpgrade
 	{
         private bool IsUsed = false;
+	    private int consecutiveActions = 0;
 
 		public PushTheLimit() : base()
 		{
@@ -30,9 +31,13 @@ namespace UpgradesList
 
         private void CheckConditions(GenericAction action)
         {
-            if (!IsUsed)
+            if (action == null)
             {
-                IsUsed = true;
+                consecutiveActions = 0;
+            }
+            else if (consecutiveActions < 1 && !IsUsed)
+            {
+                consecutiveActions++;
                 Host.OnActionDecisionSubphaseEnd += DoSecondAction;
             }
         }
@@ -65,15 +70,18 @@ namespace UpgradesList
         private void Cleanup()
         {
             IsUsed = false;
+            consecutiveActions = 0;
         }
 
 		private void AddStressToken()
 		{
-			if (!base.Host.IsFreeActionSkipped) {
+			if (!base.Host.IsFreeActionSkipped)
+			{
+			    IsUsed = true;
 				base.Host.Tokens.AssignToken (
                     new Tokens.StressToken(base.Host),
 					Triggers.FinishTrigger
-                );	
+                );
 			}
 			else
 			{
@@ -85,6 +93,5 @@ namespace UpgradesList
         {
             Phases.OnEndPhaseStart -= Cleanup;
         }
-
     }
 }


### PR DESCRIPTION
Previously PtL was marked as used after the first time it was offered to
the user. A free action from PtL is now only offered following
a successfully completed action and if PtL has not already been used.

This is not the best possible solution. Upcoming refactoring should allow
for the result of an action (taken/skipped) to be observed thus reducing
the logic for determining if PtL can be taken. This refactoring should
also remove the possibility of an infinite loop occuring do to the fact
that PtL occurs following an action and itself gives and completes an
action. Thus calling itself following the resolution of itself.