### PR TITLE
Captured TIE

### DIFF
--- a/Assets/Scripts/Model/Ships/GenericShip/GenericShipCombat.cs
+++ b/Assets/Scripts/Model/Ships/GenericShip/GenericShipCombat.cs
@@ -152,6 +152,7 @@ namespace Ship
 
         public event EventHandlerShip OnReadyToBeDestroyed;
         public event EventHandlerShipBool OnShipIsDestroyed;
+        public static event EventHandlerShipBool OnDestroyedGlobal;
 
         public event EventHandler AfterAttackWindow;
 
@@ -654,6 +655,7 @@ namespace Ship
             }
 
             if (OnShipIsDestroyed != null) OnShipIsDestroyed(this, isFled);
+            if (OnDestroyedGlobal != null) OnDestroyedGlobal(this, isFled);
 
             Triggers.ResolveTriggers(TriggerTypes.OnShipIsDestroyed, callback);
         }

--- a/Assets/Scripts/Model/Ships/GenericShip/GenericShipExtra.cs
+++ b/Assets/Scripts/Model/Ships/GenericShip/GenericShipExtra.cs
@@ -46,6 +46,8 @@ namespace Ship
 
         public event EventHandler OnDiscardUpgrade;
 
+        public event EventHandler OnFlipFaceUpUpgrade;
+
         public void CallOnShipIsPlaced(Action callback)
         {
             if (OnShipIsPlaced != null) OnShipIsPlaced(this);
@@ -58,6 +60,13 @@ namespace Ship
             if (OnDiscardUpgrade != null) OnDiscardUpgrade();
 
             Triggers.ResolveTriggers(TriggerTypes.OnDiscard, callBack);
+        }
+
+        public void CallFlipFaceUpUpgrade(Action callBack)
+        {
+            if (OnFlipFaceUpUpgrade != null) OnFlipFaceUpUpgrade();
+
+            Triggers.ResolveTriggers(TriggerTypes.OnFlipFaceUp, callBack);
         }
 
         public List<GenericShip> DockedShips = new List<GenericShip>();

--- a/Assets/Scripts/Model/Triggers.cs
+++ b/Assets/Scripts/Model/Triggers.cs
@@ -75,7 +75,8 @@ public enum TriggerTypes
     OnAbilityDirect,
     OnAbilityTargetIsSelected,
     OnMajorExplosionCrit,
-    OnDiscard
+    OnDiscard,
+    OnFlipFaceUp
 }
 
 public class Trigger

--- a/Assets/Scripts/Model/Upgrades/GenericUpgrade.cs
+++ b/Assets/Scripts/Model/Upgrades/GenericUpgrade.cs
@@ -249,13 +249,35 @@ namespace Upgrade
 
         // FLIP FACEUP
 
-        public virtual void FlipFaceup()
+        public void TryFlipFaceUp(Action callBack)
+        {
+            CurrentUpgrade = this;
+            Host.CallFlipFaceUpUpgrade(() => AfterTriedFlipFaceUp(callBack));
+        }
+
+        private void AfterTriedFlipFaceUp(Action callBack)
+        {
+            if (CurrentUpgrade != null)
+            {
+                FlipFaceup(callBack);
+            }
+            else
+            {
+                callBack();
+            }
+        }
+
+        public virtual void FlipFaceup(Action callback = null)
         {
             isDiscarded = false;
             Roster.FlipFaceupUpgrade(Host, Name);
             ActivateAbility();
 
             Messages.ShowInfo(Name + " is flipped face up");
+            if (callback != null)
+            {
+                callback();
+            }
         }
 
         public void ReplaceUpgradeBy(GenericUpgrade newUpgrade)

--- a/Assets/Scripts/Model/Upgrades/Modifications/CapturedTIE.cs
+++ b/Assets/Scripts/Model/Upgrades/Modifications/CapturedTIE.cs
@@ -1,0 +1,75 @@
+﻿using Ship;
+using Upgrade;
+using ActionsList;
+using System.Linq;
+using UnityEngine;
+using Ship.TIEFighter;
+using System.Collections.Generic;
+using System;
+
+namespace UpgradesList
+{
+    public class CapturedTIE : GenericUpgrade
+    {
+        public CapturedTIE() : base()
+        {
+            Types.Add(UpgradeType.Modification);
+            Name = "Captured TIE";
+            Cost = 1;
+            isUnique = true;
+
+            UpgradeAbilities.Add(new Abilities.CapturedTIEAbility());
+        }
+
+        public override bool IsAllowedForShip(GenericShip ship)
+        {
+            return ship is TIEFighter && ship.faction == Faction.Rebel;
+        }                
+    }
+}
+
+namespace Abilities
+{
+    public class CapturedTIEAbility : GenericAbility
+    {
+        public override void ActivateAbility()
+        {
+            GenericShip.OnTryPerformAttackGlobal += CanPerformAttack;
+            HostShip.OnAttackFinishAsAttacker += DiscardCapturedTIE;            
+        }
+
+        public override void DeactivateAbility()
+        {
+            GenericShip.OnTryPerformAttackGlobal -= CanPerformAttack;
+            HostShip.OnAttackFinishAsAttacker -= DiscardCapturedTIE;
+        }
+
+        protected void DiscardCapturedTIE(GenericShip ship)
+        {
+            HostUpgrade.TryDiscard(() => Messages.ShowInfoToHuman(string.Format("{0} discards Captured TIE", HostShip.PilotName)));            
+        }
+
+        public void CanPerformAttack(ref bool result, List<string> stringList)
+        {
+            var isNotTheCapturedTie = Selection.AnotherShip.ShipId != HostShip.ShipId;
+            var hasSameOrHigherPS = Selection.ThisShip.PilotSkill >= HostShip.PilotSkill;
+            var areThereAnyOtherEnemyShipsThanTheCapturedTie = HostShip.Owner.Ships.Values.Any(foe => foe.ShipId != HostShip.ShipId && !foe.IsDestroyed);
+
+            var allowedToBeAttacked = isNotTheCapturedTie || hasSameOrHigherPS || !areThereAnyOtherEnemyShipsThanTheCapturedTie;
+
+            if (!areThereAnyOtherEnemyShipsThanTheCapturedTie)
+            {
+                DiscardCapturedTIE(HostShip);
+            }
+
+            if (!allowedToBeAttacked)
+            {
+                if (Roster.GetPlayer(Phases.CurrentPhasePlayer).GetType() == typeof(Players.HumanPlayer))
+                {
+                    stringList.Add("Captured TIE: You cannot attack target ship");
+                }
+                result = false;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Model/Upgrades/Modifications/CapturedTIE.cs.meta
+++ b/Assets/Scripts/Model/Upgrades/Modifications/CapturedTIE.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: c2c0ede2902a2784080d78b2648e13b9
+timeCreated: 1520195280
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Based on Biggs.
"Captured TIE"'s card text specifies that the card must be discarded after an attack or when the ship is the last friendly ship.
The first event is simple, but the second happens whenever other friendly ship is destroyed.
Since the final effect is identical, I have opted for checking the second condition only when the ship equipping Captured TIE is considered for attack, instead of every time a ship is destroyed. 