### PR TITLE
Fix Pure Sabacc's ability check.

### DIFF
--- a/Assets/Scripts/Model/Ships/TIE Striker/PureSabacc.cs
+++ b/Assets/Scripts/Model/Ships/TIE Striker/PureSabacc.cs
@@ -41,7 +41,7 @@ namespace Abilities
 
         private void CheckPureSabaccAbility(ref int value)
         {
-            if (HostShip.Hull == HostShip.MaxHull) value++;
+            if (HostShip.Hull >= HostShip.MaxHull-1) value++;
         }
     }
 }

--- a/Assets/Scripts/Model/Ships/TIE Striker/PureSabacc.cs
+++ b/Assets/Scripts/Model/Ships/TIE Striker/PureSabacc.cs
@@ -41,7 +41,7 @@ namespace Abilities
 
         private void CheckPureSabaccAbility(ref int value)
         {
-            if (HostShip.Hull >= HostShip.MaxHull-1) value++;
+            if (HostShip.Damage.DamageCards.Count <= 1) value++;
         }
     }
 }


### PR DESCRIPTION
Pure Sabacc's ability is available "if you have 1 or fewer Damage cards...".