### PR TITLE
Tomax Bren

### DIFF
--- a/Assets/Scripts/Model/Ships/GenericShip/GenericShipEvents.cs
+++ b/Assets/Scripts/Model/Ships/GenericShip/GenericShipEvents.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using Upgrade;
 
 namespace Ship
 {
@@ -30,6 +31,7 @@ namespace Ship
         public delegate void EventHandlerTokensList(List<Tokens.GenericToken> tokens);
         public delegate void EventHandlerBoolStringList(ref bool result, List<string> stringList);
         public delegate void EventHandlerObjArgsBool(object sender, EventArgs e, ref bool isChanged);
+        public delegate void EventHandlerUpgrade(GenericUpgrade upgrade);
 
         public event EventHandlerShip AfterStatsAreChanged;
         public event EventHandlerInt AfterGetAgility;

--- a/Assets/Scripts/Model/Ships/GenericShip/GenericShipExtra.cs
+++ b/Assets/Scripts/Model/Ships/GenericShip/GenericShipExtra.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using Mods;
 using ActionsList;
+using Upgrade;
 
 namespace Ship
 {
@@ -51,8 +52,10 @@ namespace Ship
         public Type FromMod { get; set; }
 
         public event EventHandler OnDiscardUpgrade;
+        public event EventHandlerUpgrade OnAfterDiscardUpgrade;
 
         public event EventHandler OnFlipFaceUpUpgrade;
+        public event EventHandlerUpgrade OnAfterFlipFaceUpUpgrade;
 
         public void CallOnShipIsPlaced(Action callback)
         {
@@ -73,6 +76,20 @@ namespace Ship
             if (OnFlipFaceUpUpgrade != null) OnFlipFaceUpUpgrade();
 
             Triggers.ResolveTriggers(TriggerTypes.OnFlipFaceUp, callBack);
+        }
+
+        public void CallAfterDiscardUpgrade(GenericUpgrade discardedUpgrade, Action callBack)
+        {
+            if (OnAfterDiscardUpgrade != null) OnAfterDiscardUpgrade(discardedUpgrade);
+
+            Triggers.ResolveTriggers(TriggerTypes.OnAfterDiscard, callBack);
+        }
+
+        public void CallAfterFlipFaceUpUpgrade(GenericUpgrade flippedFaceUpUpgrade, Action callBack)
+        {
+            if (OnAfterFlipFaceUpUpgrade != null) OnAfterFlipFaceUpUpgrade(flippedFaceUpUpgrade);
+
+            Triggers.ResolveTriggers(TriggerTypes.OnAfterFlipFaceUp, callBack);
         }
 
         public List<GenericShip> DockedShips = new List<GenericShip>();

--- a/Assets/Scripts/Model/Ships/TIE Bomber/TomaxBren.cs
+++ b/Assets/Scripts/Model/Ships/TIE Bomber/TomaxBren.cs
@@ -1,0 +1,53 @@
+﻿using ActionList;
+using Ship;
+using Upgrade;
+
+namespace Ship
+{
+    namespace TIEBomber
+    {
+        public class TomaxBren : TIEBomber
+        {
+            public TomaxBren() : base()
+            {
+                PilotName = "Tomax Bren";
+                PilotSkill = 8;
+                Cost = 24;
+
+                IsUnique = true;
+
+                PrintedUpgradeIcons.Add(Upgrade.UpgradeType.Elite);
+
+                PilotAbilities.Add(new Abilities.TomaxBrenAbility());
+            }
+        }
+    }
+}
+
+namespace Abilities
+{
+    public class TomaxBrenAbility : GenericAbility
+    {
+        public override void ActivateAbility()
+        {
+            HostShip.OnAfterDiscardUpgrade += CheckTomaxBrenAbility;
+            Phases.OnRoundEnd += ClearIsAbilityUsedFlag;
+        }
+
+        public override void DeactivateAbility()
+        {
+            HostShip.OnAfterDiscardUpgrade -= CheckTomaxBrenAbility;
+            Phases.OnRoundEnd -= ClearIsAbilityUsedFlag;
+        }
+
+        private void CheckTomaxBrenAbility(GenericUpgrade upgrade)
+        {            
+            if (!IsAbilityUsed && upgrade.hasType(UpgradeType.Elite))
+            {
+                IsAbilityUsed = true;
+                Messages.ShowInfo(string.Format("{0} flips {1} face up.", HostShip.PilotName, upgrade.Name));
+                RegisterAbilityTrigger(TriggerTypes.OnAfterDiscard, (s, e) => upgrade.TryFlipFaceUp(Triggers.FinishTrigger));
+            }
+        }                 
+    }
+}

--- a/Assets/Scripts/Model/Ships/TIE Bomber/TomaxBren.cs.meta
+++ b/Assets/Scripts/Model/Ships/TIE Bomber/TomaxBren.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 05595ed8a8f97f04a85a32bfff247a94
+timeCreated: 1521132850
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Model/Triggers.cs
+++ b/Assets/Scripts/Model/Triggers.cs
@@ -76,7 +76,9 @@ public enum TriggerTypes
     OnAbilityTargetIsSelected,
     OnMajorExplosionCrit,
     OnDiscard,
-    OnFlipFaceUp
+    OnFlipFaceUp,
+    OnAfterDiscard,
+    OnAfterFlipFaceUp
 }
 
 public class Trigger

--- a/Assets/Scripts/Model/Upgrades/GenericUpgrade.cs
+++ b/Assets/Scripts/Model/Upgrades/GenericUpgrade.cs
@@ -244,7 +244,7 @@ namespace Upgrade
             Roster.DiscardUpgrade(Host, Name);
             DeactivateAbility();
 
-            callBack();
+            Host.CallAfterDiscardUpgrade(this, callBack);
         }
 
         // FLIP FACEUP
@@ -274,10 +274,7 @@ namespace Upgrade
             ActivateAbility();
 
             Messages.ShowInfo(Name + " is flipped face up");
-            if (callback != null)
-            {
-                callback();
-            }
+            Host.CallAfterFlipFaceUpUpgrade(this, callback);
         }
 
         public void ReplaceUpgradeBy(GenericUpgrade newUpgrade)


### PR DESCRIPTION
I had to add a couple new events.
Currently we have OnDiscard and OnFlipFaceUp.
These events are triggered when upgrades are about to be discarded (or flipped face up), so that effects like Extra Munitions can prevent it.
However we needed events for after the discarding (or flipping face up) is complete to trigger effects that happen after something has been discarded, like Tomax Bren's ability.
So I added OnAfterDiscard and OnAfterFlipFaceUp. (The .Net nomenclature for these would have been Discarding and Discarded, and FlippingFaceUp and FlippedFaceUp, to distinguish what can be prevented from what is consumated).

I could have gone the path of Tomax Bren preventing the discarding of the upgrade. But that isn't semantically exact to his card text, and could come back to us in the future when more game effects are triggered after the discarding or flipping face up of an upgrade card.