### PR TITLE
"Deathfire"

### DIFF
--- a/Assets/Scripts/Model/Ships/TIE Bomber/Deathfire.cs
+++ b/Assets/Scripts/Model/Ships/TIE Bomber/Deathfire.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Linq;
+using ActionList;
+using ActionsList;
+using Ship;
+using Upgrade;
+
+namespace Ship
+{
+    namespace TIEBomber
+    {
+        public class Deathfire : TIEBomber
+        {
+            public Deathfire() : base()
+            {
+                PilotName = "\"Deathfire\"";
+                PilotSkill = 3;
+                Cost = 17;
+
+                IsUnique = true;
+
+                PilotAbilities.Add(new Abilities.DeathfireAbility());
+            }
+        }
+    }
+}
+
+namespace Abilities
+{
+    public class DeathfireAbility : GenericAbility
+    {
+        public override void ActivateAbility()
+        {
+            HostShip.OnManeuverIsRevealed += CheckDeathfireAbility;
+            HostShip.OnActionIsPerformed += CheckDeathfireAbility;            
+        }
+
+        public override void DeactivateAbility()
+        {
+            HostShip.OnManeuverIsRevealed -= CheckDeathfireAbility;
+            HostShip.OnActionIsPerformed -= CheckDeathfireAbility;
+        }
+
+        private void CheckDeathfireAbility(GenericAction action)
+        {
+            if (!IsAbilityUsed && action != null)
+            {
+                SetIsAbilityIsUsed(HostShip);
+                RegisterAbilityTrigger(TriggerTypes.OnActionIsPerformed, DeathfireEffect);
+            }
+        }
+
+        private void CheckDeathfireAbility(GenericShip ship)
+        {
+            if (!IsAbilityUsed)
+            {
+                SetIsAbilityIsUsed(HostShip);
+                RegisterAbilityTrigger(TriggerTypes.OnManeuverIsRevealed, DeathfireEffect);
+            }
+        }
+
+        private void DeathfireEffect(object sender, EventArgs e)
+        {
+            HostShip.GenerateAvailableActionsList();
+            var actions = HostShip.GetAvailableActionsList()
+                .Where(action => action is BombDropAction)
+                .ToList();
+
+            HostShip.AskPerformFreeAction(actions, () =>
+            {
+                ClearIsAbilityUsedFlag();
+                Triggers.FinishTrigger();                
+            });
+        }        
+    }
+}

--- a/Assets/Scripts/Model/Ships/TIE Bomber/Deathfire.cs.meta
+++ b/Assets/Scripts/Model/Ships/TIE Bomber/Deathfire.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 0bc1d7a8b119ab84581155b165b63949
+timeCreated: 1521149732
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
I have reused IsAbilityUsed not as it usually was intended to be used (once per round abilities) but as a way to stop an infinite recursive check chain.
("Deathfire" gets to do an action, does it, his ability triggers and offers to do a bomb action, does it, his ability triggers and offers to do another action, says Skip (but that counts as doing a null action) that triggers his ability, ... and so on and on). 
To avoid that, when his ability trigger starts resolving, the ability is marked as used, so that it isn't triggered again during its resolution. When its ability trigger ends, the ability is unmarked as used so that it can trigger at a later point again.