### PR TITLE
Fixes issue where Manaroo cannot re-assign tokens

### DIFF
--- a/Assets/Scripts/Model/Actions/Actions.cs
+++ b/Assets/Scripts/Model/Actions/Actions.cs
@@ -296,7 +296,7 @@ public static partial class Actions
 
         if (simpleTokens.Contains(tokenToReassign.GetType()))
         {
-            GenericToken tokenToAssign = (GenericToken)Activator.CreateInstance(tokenToReassign.GetType());
+            GenericToken tokenToAssign = (GenericToken)Activator.CreateInstance(tokenToReassign.GetType(), new [] { toShip });
             fromShip.Tokens.RemoveToken(
                 tokenToReassign.GetType(),
                 delegate {


### PR DESCRIPTION
Fixes an exception being thrown due to missing no-arg constructor for Tokens during Manaroos ability.  Makes the assumption that all tokens only take a single ship as the parameter.