### PR TITLE
Coordinate fix

### DIFF
--- a/Assets/Scripts/Model/Actions/ActionsList/CoordinateAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/CoordinateAction.cs
@@ -78,6 +78,7 @@ namespace SubPhases
 
         private void PerformCoordinateEffect()
         {
+            var coordinatingShip = Selection.ThisShip;
             Selection.ThisShip = TargetShip;
 
             Triggers.RegisterTrigger(
@@ -93,6 +94,7 @@ namespace SubPhases
             MovementTemplates.ReturnRangeRuler();
 
             Triggers.ResolveTriggers(TriggerTypes.OnFreeActionPlanned, delegate {
+                Selection.ThisShip = coordinatingShip;
                 Phases.FinishSubPhase(typeof(CoordinateTargetSubPhase));
                 CallBack();
             });


### PR DESCRIPTION
When ship A uses Advanced Sensors to coordinate ship B, after B does its free action, it immediately "steals" the rest of the activation phase from A, then if higher PS, ship B will activate yet again.
Fixed by re-assigning the Selection ship back to the coordinating ship before the coordinate subphase ends.