### PR TITLE
Renegade Refit and Servomotor S-Foils

### DIFF
--- a/Assets/Scripts/Model/Upgrades/Modifications/ServomoterSFoils.cs
+++ b/Assets/Scripts/Model/Upgrades/Modifications/ServomoterSFoils.cs
@@ -2,20 +2,42 @@
 using Upgrade;
 using Abilities;
 using Ship.XWing;
+using System.Linq;
+using ActionsList;
+using Movement;
+using GameModes;
+using System.Collections.Generic;
+using System;
+using SubPhases;
 
 namespace UpgradesList
 {
-    public class ServomoterSFoils : GenericUpgrade
+    public class ServomotorSFoilsClosed : GenericDualUpgrade
     {
-        public ServomoterSFoils() : base()
+        public ServomotorSFoilsClosed() : base()
         {
             Types.Add(UpgradeType.Modification);
-            Name = "Servomoter S-Foils";
+            Name = "Servomotor S-Foils (Closed)";
+            Cost = 0;                        
+            UpgradeAbilities.Add(new ServomotorSFoilsClosedAbility());
+            AnotherSide = typeof(ServomotorSFoilsAttack);
+        }
+
+        public override bool IsAllowedForShip(GenericShip ship)
+        {
+            return ship is XWing;
+        }
+    }
+
+    public class ServomotorSFoilsAttack : GenericDualUpgrade
+    {
+        public ServomotorSFoilsAttack() : base()
+        {
+            Types.Add(UpgradeType.Modification);
+            Name = "Servomotor S-Foils (Attack)";
             Cost = 0;
-
-            IsHidden = true;
-
-            UpgradeAbilities.Add(new ServomoterSFoilsAbility());
+            UpgradeAbilities.Add(new ServomotorSFoilsAttackAbility());
+            AnotherSide = typeof(ServomotorSFoilsClosed);
         }
 
         public override bool IsAllowedForShip(GenericShip ship)
@@ -28,26 +50,157 @@ namespace UpgradesList
 
 namespace Abilities
 {
-    public class ServomoterSFoilsAbility : GenericAbility
+    public abstract class ServomotorSFoilCommonAbility : GenericAbility
     {
+        protected void TurnSFoilsToClosedPosition(GenericShip ship)
+        {
+            HostShip.WingsClose();
+        }
+
+        protected void TurnSFoilsToAttackPosition(GenericShip ship)
+        {
+            HostShip.WingsOpen();
+        }
+
+        private void RegisterAskToUseFlip()
+        {
+            RegisterAbilityTrigger(TriggerTypes.OnActivationPhaseStart, AskToFlip);
+        }
+
+        protected void AskToFlip(object sender, EventArgs e)
+        {
+            Messages.ShowInfo(string.Format("{0} may flip {1}", HostShip.PilotName, HostUpgrade.Name));
+            AskToUseAbility(NeverUseByDefault, DoFlipSide);            
+        }
+
+        protected void DoFlipSide(object sender, EventArgs e)
+        {
+            (HostUpgrade as GenericDualUpgrade).Flip();
+            DecisionSubPhase.ConfirmDecision();
+        }
 
         public override void ActivateAbility()
         {
-            HostShip.OnShipIsPlaced += TurnSFoilsToFlightPositionAlt;
-            Phases.OnCombatPhaseStart_NoTriggers += HostShip.WingsOpen;
-            Phases.OnCombatPhaseEnd_NoTriggers += HostShip.WingsClose;
+            Phases.OnActivationPhaseStart += RegisterAskToUseFlip;
         }
 
         public override void DeactivateAbility()
         {
-            HostShip.OnShipIsPlaced -= TurnSFoilsToFlightPositionAlt;
-            Phases.OnCombatPhaseStart_NoTriggers -= HostShip.WingsOpen;
-            Phases.OnCombatPhaseEnd_NoTriggers -= HostShip.WingsClose;
+            Phases.OnActivationPhaseStart -= RegisterAskToUseFlip;
         }
 
-        private void TurnSFoilsToFlightPositionAlt(GenericShip ship)
+    }
+
+    public class ServomotorSFoilsClosedAbility : ServomotorSFoilCommonAbility
+    {
+
+        public override void ActivateAbility()
         {
-            HostShip.WingsClose();
+            base.ActivateAbility();
+            TurnSFoilsToClosedPosition(HostShip);
+            HostShip.ChangeFirepowerBy(-1);
+            HostShip.AfterGenerateAvailableActionsList += AddActionIcon;
+            HostShip.AfterGetManeuverColorDecreaseComplexity += CheckServomotorManeuverAbility;
+        }
+                
+        public override void DeactivateAbility()
+        {
+            base.DeactivateAbility();
+            TurnSFoilsToAttackPosition(HostShip);
+            HostShip.ChangeFirepowerBy(+1);
+            HostShip.AfterGenerateAvailableActionsList -= AddActionIcon;
+            HostShip.AfterGetManeuverColorDecreaseComplexity -= CheckServomotorManeuverAbility;
+        }
+
+        protected void CheckServomotorManeuverAbility(GenericShip ship, ref MovementStruct movement)
+        {
+            if (movement.ColorComplexity != ManeuverColor.None)
+            {
+                if ((movement.Speed == ManeuverSpeed.Speed2) && (movement.Bearing == ManeuverBearing.Bank))
+                {
+                    movement.ColorComplexity = ManeuverColor.Green;
+                }
+            }
+        }
+
+        protected void AddActionIcon(GenericShip host)
+        {
+            var alreadyHasBarrelRoll = host.PrintedActions.Any(n => n is BoostAction);
+            if (!alreadyHasBarrelRoll)
+            {
+                host.AddAvailableAction(new BoostAction());
+            }
+        }
+    }
+
+    public class ServomotorSFoilsAttackAbility : ServomotorSFoilCommonAbility
+    {
+        List<string> allowedMovements = new List<string>();
+        public override void ActivateAbility()
+        {
+            base.ActivateAbility();
+            HostShip.AfterGenerateAvailableActionsList += AddActionIcon;
+            HostShip.OnManeuverIsRevealed += RegisterAskChangeManeuver;            
+        }
+
+        public override void DeactivateAbility()
+        {
+            base.DeactivateAbility();
+            HostShip.AfterGenerateAvailableActionsList -= AddActionIcon;
+            HostShip.OnManeuverIsRevealed -= RegisterAskChangeManeuver;            
+        }               
+        
+        private void RegisterAskChangeManeuver(GenericShip ship)
+        {
+            if (HostShip.AssignedManeuver.Bearing == ManeuverBearing.Turn && HostShip.AssignedManeuver.Speed == 3 && HostShip.Tokens.CountTokensByType(typeof(Tokens.StressToken)) == 0)
+            {
+                RegisterAbilityTrigger(TriggerTypes.OnManeuverIsRevealed, AskChangeManeuver);
+            }
+        }
+
+        private void AskChangeManeuver(object sender, System.EventArgs e)
+        {
+            Messages.ShowInfoToHuman("Servomotor S-foils: You can change your maneuver to red Tallon roll");
+            allowedMovements.Clear();
+            var direction = HostShip.AssignedManeuver.Direction == ManeuverDirection.Left ? "L" : "R";
+            var turnCode = "3." + direction + ".T";
+            var tallonCode = "3." + direction + ".E";
+            allowedMovements.Add(turnCode);
+            allowedMovements.Add(tallonCode);
+            var hadTallonBefore = false;
+            var originalTallonColor = ManeuverColor.None;
+            if (HostShip.Maneuvers.ContainsKey(tallonCode))
+            {
+                hadTallonBefore = true;
+                originalTallonColor = HostShip.Maneuvers[tallonCode];
+            }            
+            HostShip.Maneuvers[tallonCode] = ManeuverColor.Red;
+            HostShip.Owner.ChangeManeuver((maneuverCode) => 
+            {
+                GameMode.CurrentGameMode.AssignManeuver(maneuverCode);
+                if (hadTallonBefore)
+                {
+                    HostShip.Maneuvers[tallonCode] = originalTallonColor;
+                }
+                else
+                {
+                    HostShip.Maneuvers.Remove(tallonCode);
+                }
+            }, TurnOrTallonRoll);
+        }
+
+        private bool TurnOrTallonRoll(string maneuverString)
+        {            
+            var result = allowedMovements.Contains(maneuverString);
+            return result;
+        }
+        protected void AddActionIcon(GenericShip host)
+        {
+            var alreadyHasBarrelRoll = host.PrintedActions.Any(n => n is BarrelRollAction);
+            if (!alreadyHasBarrelRoll)
+            {
+                host.AddAvailableAction(new BarrelRollAction());
+            }
         }
     }
 }

--- a/Assets/Scripts/Model/Upgrades/Torpedoes/RenegadeRefit.cs
+++ b/Assets/Scripts/Model/Upgrades/Torpedoes/RenegadeRefit.cs
@@ -1,0 +1,51 @@
+﻿using Ship;
+using Ship.UWing;
+using Ship.XWing;
+using System.Collections.Generic;
+using System.Linq;
+using Upgrade;
+
+namespace UpgradesList
+{
+
+    public class RenegadeRefit : GenericUpgradeSlotUpgrade
+    {
+        public RenegadeRefit() : base()
+        {
+            Types.Add(UpgradeType.Torpedo);
+
+            Name = "Renegade Refit";
+            Cost = -2;
+            AddedSlots = new List<UpgradeSlot>
+            {
+                new UpgradeSlot(UpgradeType.Modification) { MustBeDifferent = true }
+            };
+        }
+
+        public override bool IsAllowedForShip(GenericShip ship)
+        {
+            return ship is XWing || ship is UWing;
+        }
+
+        public override void PreAttachToShip(GenericShip host)
+        {
+            base.PreAttachToShip(host);
+
+            foreach (var slot in host.UpgradeBar.GetUpgradeSlots().Where(s => s.Type == UpgradeType.Elite))
+            {
+                slot.CostDecrease++;
+            }
+        }
+
+        public override void PreDettachFromShip()
+        {
+            base.PreDettachFromShip();
+
+            foreach (var slot in Host.UpgradeBar.GetUpgradeSlots().Where(s => s.Type == UpgradeType.Elite))
+            {
+                slot.CostDecrease--;
+            }
+        }
+    }
+}
+

--- a/Assets/Scripts/Model/Upgrades/Torpedoes/RenegadeRefit.cs.meta
+++ b/Assets/Scripts/Model/Upgrades/Torpedoes/RenegadeRefit.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: a6bccf519f260964289505fe94ed8b96
+timeCreated: 1524633740
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
TODO:
- For Renegade Refit to work, Torpedoes need to have a chance to add the extra slots during squadron spawn.
- Servomotor S-Foil (Closed) needs to ask the player whether he wants the 2 banks to be white or green, since the player might have dialed the 2 bank before this side of the card was flipped up.