### PR TITLE
Minor fixes to Spacetug Array and Servomotor S-Foils

### DIFF
--- a/Assets/Scripts/Model/Phases/SubPhases/Temporary/SelectShipSubPhase.cs
+++ b/Assets/Scripts/Model/Phases/SubPhases/Temporary/SelectShipSubPhase.cs
@@ -258,6 +258,7 @@ namespace SubPhases
         {
             Phases.CurrentSubPhase = PreviousSubPhase;
             Roster.AllShipsHighlightOff();
+            HideSubphaseDescription();
             Phases.CurrentSubPhase.Resume();
             UpdateHelpInfo();
         }

--- a/Assets/Scripts/Model/Upgrades/Modifications/ServomoterSFoils.cs
+++ b/Assets/Scripts/Model/Upgrades/Modifications/ServomoterSFoils.cs
@@ -52,6 +52,8 @@ namespace Abilities
 {
     public abstract class ServomotorSFoilCommonAbility : GenericAbility
     {
+        protected abstract bool AIWantsToFlip();
+
         protected void TurnSFoilsToClosedPosition(GenericShip ship)
         {
             HostShip.WingsClose();
@@ -69,7 +71,7 @@ namespace Abilities
 
         protected void AskToFlip(object sender, EventArgs e)
         {            
-            AskToUseAbility(NeverUseByDefault, DoFlipSide, null, null, false, string.Format("{0}: Do you want to flip Servomotor S-Foils?", HostShip.PilotName));            
+            AskToUseAbility(AIWantsToFlip, DoFlipSide, null, null, false, string.Format("{0}: Do you want to flip Servomotor S-Foils?", HostShip.PilotName));            
         }
 
         protected void DoFlipSide(object sender, EventArgs e)
@@ -126,6 +128,12 @@ namespace Abilities
                 HostShip.AssignedManeuver.ColorComplexity = ManeuverColor.Green;
                 Roster.UpdateAssignedManeuverDial(HostShip, HostShip.AssignedManeuver);
             }
+        }
+
+        protected override bool AIWantsToFlip()
+        {
+            /// TODO: Add more inteligence to this decision
+            return true;
         }
     }
 
@@ -197,6 +205,12 @@ namespace Abilities
             {
                 host.AddAvailableAction(new BarrelRollAction());
             }
+        }
+
+        protected override bool AIWantsToFlip()
+        {
+            /// TODO: Add more inteligence to this decision
+            return false;
         }
     }
 }

--- a/Assets/Scripts/Model/Upgrades/Modifications/SpaceTugTractorArray.cs
+++ b/Assets/Scripts/Model/Upgrades/Modifications/SpaceTugTractorArray.cs
@@ -123,6 +123,11 @@ namespace SubPhases
             TargetShip.Tokens.AssignToken(token, SelectShipSubPhase.FinishSelection);
         }
 
+        public override void SkipButton()
+        {
+            Phases.FinishSubPhase(typeof(SelectSpacetugTargetSubPhase));
+            CallBack();
+        }
     }
 }
 


### PR DESCRIPTION
Spacetug Array: When selecting an invalid target or skipping the action, hide the subphase description.
Servomotor S-Foils: The AI shoulnd't be flipping it whenever it has the chance. Instead, it now always tries to keep the Attack side face up.