### PR TITLE
Fixes to ISB Slice and Jam action

### DIFF
--- a/Assets/Scripts/Model/Actions/ActionsList/JamAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/JamAction.cs
@@ -102,19 +102,24 @@ namespace SubPhases
             });
         }
 
-        public override void RevertSubPhase() { }
-
         private void AssignJamToken(GenericShip targetShip)
         {
             targetShip.Tokens.AssignToken(new JamToken(targetShip), Triggers.FinishTrigger);
         }
 
-        public override void SkipButton()
+        public override void RevertSubPhase()
         {
-            Phases.FinishSubPhase(typeof(JamTargetSubPhase));
-            CallBack();
+            Selection.ThisShip.RemoveAlreadyExecutedAction(typeof(ActionsList.JamAction));
+
+            Phases.FinishSubPhase(this.GetType());
+            Phases.CurrentSubPhase.Resume();
+            UpdateHelpInfo();
         }
 
+        public override void SkipButton()
+        {
+            RevertSubPhase();
+        }
     }
 
 }

--- a/Assets/Scripts/Model/Upgrades/Crew/ISBSlicer.cs
+++ b/Assets/Scripts/Model/Upgrades/Crew/ISBSlicer.cs
@@ -55,7 +55,12 @@ namespace Abilities
         {            
             if (action is JamAction && jamTarget != null)
             {
-                RegisterAbilityTrigger(TriggerTypes.OnActionIsPerformed, ISBSlicerEffect);
+                var anyCandidate = Roster.AllShips.Values
+                    .Any(s => IsShipWithoutJamAtRangeOneOfTarget(s));
+                if (anyCandidate)
+                {
+                    RegisterAbilityTrigger(TriggerTypes.OnActionIsPerformed, ISBSlicerEffect);
+                }
             }
         }
 
@@ -80,10 +85,8 @@ namespace Abilities
         }
         
         private bool IsShipWithoutJamAtRangeOneOfTarget(GenericShip ship)
-        {
-            var filters = new[] { TargetTypes.OtherFriendly, TargetTypes.This, TargetTypes.Enemy }
-                .ToList();
-            var match = FilterByTargetType(ship, filters) && Board.BoardManager.GetRangeOfShips(jamTarget, ship) <= 1;
+        {            
+            var match = !ship.Tokens.HasToken<JamToken>() && Board.BoardManager.GetRangeOfShips(jamTarget, ship) <= 1;
             return match;
         }
 


### PR DESCRIPTION
Fixes to ISB Slicer: Only selectable ships that aren't Jammed. Only triggers if there are any eligible ships.
Fixes to Jam action: If no ship is eligible, it allows a different action.