### PR TITLE
SE: R5 Astromechs

### DIFF
--- a/Assets/Scripts/Model/Ships/GenericShip/Damage/AssignedDamageCards.cs
+++ b/Assets/Scripts/Model/Ships/GenericShip/Damage/AssignedDamageCards.cs
@@ -16,9 +16,9 @@ namespace Ship
             DamageCards = new List<GenericDamageCard>();
         }
 
-        public List<GenericDamageCard> GetFaceupCrits()
+        public List<GenericDamageCard> GetFaceupCrits(CriticalCardType? type = null)
         {
-            return DamageCards.Where(n => n.IsFaceup).ToList();
+            return DamageCards.Where(n => n.IsFaceup && (n.Type == type || type == null)).ToList();
         }
 
         public List<GenericDamageCard> GetFacedownCards()
@@ -40,7 +40,7 @@ namespace Ship
             if (faceDownCards.Count != 0)
             {
                 result = true;
-                faceDownCards.RemoveAt(0);
+                DamageCards.Remove(faceDownCards.First());
                 Host.CallAfterAssignedDamageIsChanged();
             }
             return result;

--- a/Assets/Scripts/Model/Upgrades/Astromech/R5Astromech.cs
+++ b/Assets/Scripts/Model/Upgrades/Astromech/R5Astromech.cs
@@ -1,10 +1,10 @@
 ﻿using System.Linq;
-using System.Collections;
 using System.Collections.Generic;
-using UnityEngine;
 using Upgrade;
 using Abilities;
 using RuleSets;
+using ActionsList;
+using System;
 
 namespace UpgradesList
 {
@@ -25,6 +25,9 @@ namespace UpgradesList
             MaxCharges = 2;
 
             ImageUrl = "https://i.imgur.com/B7zcHyk.png";
+
+            UpgradeAbilities.RemoveAll(a => a is R5AstromechAbility);
+            UpgradeAbilities.Add(new Abilities.SecondEdition.R5AstromechAbility());
         }
     }
 
@@ -107,4 +110,108 @@ namespace SubPhases
 
     }
 
+}
+
+
+namespace Abilities.SecondEdition
+{
+    //Action: Spend 1 charge to repair 1 facedown damage card.
+    //Action: Repair 1 faceup Ship damage card.
+    public class R5AstromechAbility : GenericAbility
+    {
+        public override void ActivateAbility()
+        {
+            HostShip.AfterGenerateAvailableActionsList += AddAction;
+        }
+
+        public override void DeactivateAbility()
+        {
+            HostShip.AfterGenerateAvailableActionsList -= AddAction;
+        }
+
+        private void AddAction(Ship.GenericShip ship)
+        {
+            if (ship.Damage.GetFacedownCards().Any() && HostUpgrade.Charges > 0)
+            {
+                ship.AddAvailableAction(new RepairAction(RepairAction.CardFace.FaceDown)
+                {
+                    ImageUrl = HostUpgrade.ImageUrl,
+                    Host = HostShip,
+                    PayRepairCost = () =>
+                    {
+                        var result = false;
+                        if (HostUpgrade.Charges > 0) HostUpgrade.SpendCharge(() => result = true);
+                        return result;
+                    }
+                });
+            }
+            if (ship.Damage.GetFaceupCrits(CriticalCardType.Ship).Any())
+            {
+                ship.AddAvailableAction(new RepairAction(RepairAction.CardFace.FaceUp, CriticalCardType.Ship)
+                {
+                    ImageUrl = HostUpgrade.ImageUrl,
+                    Host = HostShip
+                });
+            }
+        }
+    }
+}
+
+namespace ActionsList
+{
+    public class RepairAction : GenericAction
+    {
+        public enum CardFace
+        {
+            FaceDown,
+            FaceUp
+        }
+
+        public Func<bool> PayRepairCost = () => true;
+
+        private readonly CardFace damageCardFace;
+        private readonly CriticalCardType? criticalCardType;
+
+        public RepairAction(CardFace face, CriticalCardType? type = null)
+        {
+            damageCardFace = face;
+            criticalCardType = type;
+
+            EffectName = Name = "Repair 1 " + face.ToString().ToLower() + (type != null ? " " + type.ToString() : "")  + " damage";
+        }
+
+        public override void ActionTake()
+        {
+            if (PayRepairCost())
+            {
+                if (damageCardFace == CardFace.FaceDown)
+                {
+                    if (Host.Damage.DiscardRandomFacedownCard())
+                    {
+                        Sounds.PlayShipSound("R2D2-Proud");
+                        Messages.ShowInfoToHuman("Facedown Damage card is discarded");
+                    }
+                }
+                else if (damageCardFace == CardFace.FaceUp)
+                {
+                    List<GenericDamageCard> shipCritsList = Host.Damage.GetFaceupCrits(criticalCardType);
+
+
+                    if (shipCritsList.Count == 1)
+                    {
+                        Host.Damage.FlipFaceupCritFacedown(shipCritsList.First());
+                        Sounds.PlayShipSound("R2D2-Proud");
+                    }
+                    else if (shipCritsList.Count > 1)
+                    {
+                        Phases.StartTemporarySubPhaseOld(
+                            Source.Name + ": Select faceup ship Crit",
+                            typeof(SubPhases.R5AstromechDecisionSubPhase)
+                        );
+                    }
+                }
+            }
+            Phases.CurrentSubPhase.CallBack();
+        }
+    }
 }

--- a/Assets/Scripts/Model/Upgrades/Astromech/R5Astromech.cs
+++ b/Assets/Scripts/Model/Upgrades/Astromech/R5Astromech.cs
@@ -56,7 +56,7 @@ namespace Abilities
         {
             Selection.ActiveShip = HostShip;
 
-            List<GenericDamageCard> shipCritsList = HostShip.Damage.GetFaceupCrits();
+            List<GenericDamageCard> shipCritsList = HostShip.Damage.GetFaceupCrits(CriticalCardType.Ship);
 
             if (shipCritsList.Count == 1)
             {
@@ -90,7 +90,7 @@ namespace SubPhases
         {
             InfoText = "R5 Astromech: Select faceup ship Crit";
 
-            foreach (var shipCrit in Selection.ActiveShip.Damage.GetFaceupCrits().Where(n => n.Type == CriticalCardType.Ship).ToList())
+            foreach (var shipCrit in Selection.ActiveShip.Damage.GetFaceupCrits(CriticalCardType.Ship).ToList())
             {
                 //TODO: what if two same crits?
                 AddDecision(shipCrit.Name, delegate { DiscardCrit(shipCrit); });

--- a/Assets/Scripts/Model/Upgrades/Astromech/R5D8.cs
+++ b/Assets/Scripts/Model/Upgrades/Astromech/R5D8.cs
@@ -1,13 +1,11 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using Upgrade;
+﻿using Upgrade;
 using Abilities;
+using RuleSets;
 
 namespace UpgradesList
 {
 
-    public class R5D8 : GenericUpgrade
+    public class R5D8 : GenericUpgrade, ISecondEditionUpgrade
     {
         public R5D8() : base()
         {
@@ -17,6 +15,16 @@ namespace UpgradesList
             Cost = 3;
 
             UpgradeAbilities.Add(new R5D8Ability());
+        }
+
+        public void AdaptUpgradeToSecondEdition()
+        {
+            MaxCharges = 3;
+
+            ImageUrl = "https://i.imgur.com/p5VRdvO.png";
+
+            UpgradeAbilities.RemoveAll(a => a is R5D8Ability);
+            UpgradeAbilities.Add(new Abilities.SecondEdition.R5AstromechAbility());
         }
     }
 
@@ -75,7 +83,6 @@ namespace ActionsList
 
 namespace SubPhases
 {
-
     public class R5D8CheckSubPhase : DiceRollCheckSubPhase
     {
 


### PR DESCRIPTION
Also fixed bug where DiscardRandomFacedownCard method didn't actually discard anything

Note:
First Edition crits that should flip themselves down doesn't seem to work. The crit token disappears, but the faceUp property is still true, so the R5 astromechs treat them as faceup cards.

And AssignedDamageCards.FlipFaceupCritFacedown method doesn't flip the card, but discards it altogether...