### PR TITLE
Red maneuver shouldn't cause action step to be skipped

### DIFF
--- a/Assets/Scripts/Model/Phases/SubPhases/ActionSubphase.cs
+++ b/Assets/Scripts/Model/Phases/SubPhases/ActionSubphase.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using Tokens;
 using UnityEngine;
 
 namespace SubPhases
@@ -22,25 +23,22 @@ namespace SubPhases
         public override void Initialize()
         {
             Phases.Events.CallBeforeActionSubPhaseTrigger();
+            var ship = Selection.ThisShip;
 
-            if (!Selection.ThisShip.IsSkipsActionSubPhase)
+            bool canPerformAction = !(ship.IsSkipsActionSubPhase  || ship.IsDestroyed
+                                    || (ship.Tokens.HasToken(typeof(StressToken)) && !ship.CanPerformActionsWhileStressed));
+
+            if (canPerformAction)
             {
-                if (!Selection.ThisShip.IsDestroyed)
-                {
-                    Selection.ThisShip.GenerateAvailableActionsList();
-                    Triggers.RegisterTrigger(
-                        new Trigger() {
-                            Name = "Action",
-                            TriggerOwner = Phases.CurrentPhasePlayer,
-                            TriggerType = TriggerTypes.OnActionSubPhaseStart,
-                            EventHandler = StartActionDecisionSubphase
-                        }
-                    );
-                }
-                else
-                {
-                    //Next();
-                }
+                ship.GenerateAvailableActionsList();
+                Triggers.RegisterTrigger(
+                    new Trigger() {
+                        Name = "Action",
+                        TriggerOwner = Phases.CurrentPhasePlayer,
+                        TriggerType = TriggerTypes.OnActionSubPhaseStart,
+                        EventHandler = StartActionDecisionSubphase
+                    }
+                );                
             }
 
             Phases.Events.CallOnActionSubPhaseTrigger();

--- a/Assets/Scripts/Model/Rules/RulesList/StressRule.cs
+++ b/Assets/Scripts/Model/Rules/RulesList/StressRule.cs
@@ -35,10 +35,10 @@ namespace RulesList
                 case MovementComplexity.Complex:
                     if (Selection.ThisShip.Owner.GetType() != typeof(HotacAiPlayer))
                     {
-                        Selection.ThisShip.Tokens.AssignToken(new StressToken(Selection.ThisShip), delegate {
-                            Selection.ThisShip.IsSkipsActionSubPhase = Selection.ThisShip.Tokens.HasToken(typeof(StressToken)) && !Selection.ThisShip.CanPerformActionsWhileStressed;
-                            Triggers.FinishTrigger();
-                        });
+                        Selection.ThisShip.Tokens.AssignToken(
+                            new StressToken(Selection.ThisShip), 
+                            Triggers.FinishTrigger
+                        );
                     }
                     else
                     {


### PR DESCRIPTION
Since the stress can be removed before the action phase begins (Hobbie with Targeting Astro)
Instead, stress should be checked at the beginning of the action subphase

Fixes #955 