### PR TITLE
Implemented Threat Tracker

### DIFF
--- a/Assets/Scripts/Model/Upgrades/Elite/PushTheLimit.cs
+++ b/Assets/Scripts/Model/Upgrades/Elite/PushTheLimit.cs
@@ -95,6 +95,8 @@ namespace Abilities
             {
                 Triggers.FinishTrigger();
             }
+            // Reset after every Push the Limit opportunity
+            consecutiveActions = 0;
         }
     }
 }

--- a/Assets/Scripts/Model/Upgrades/Tech/ThreatTracker.cs
+++ b/Assets/Scripts/Model/Upgrades/Tech/ThreatTracker.cs
@@ -86,7 +86,6 @@ namespace Abilities
 
         private void PerformThreatTracker(object sender, EventArgs e)
         {
-            GenericShip originalSelectedShip = Selection.ThisShip;
             Selection.ChangeActiveShip(HostShip);
             HostShip.AskPerformFreeAction(
                 threatTrackerActions,

--- a/Assets/Scripts/Model/Upgrades/Tech/ThreatTracker.cs
+++ b/Assets/Scripts/Model/Upgrades/Tech/ThreatTracker.cs
@@ -1,0 +1,97 @@
+﻿using Upgrade;
+using UnityEngine;
+using Ship;
+using System.Collections.Generic;
+using Abilities;
+using BoardTools;
+using SubPhases;
+using UpgradesList;
+using ActionsList;
+using System;
+
+namespace UpgradesList
+{
+
+    public class ThreatTracker : GenericUpgrade
+    {
+        public ThreatTracker() : base()
+        {
+            Types.Add(UpgradeType.Tech);
+            Name = "Threat Tracker";
+            Cost = 3;
+
+            UpgradeAbilities.Add(new ThreatTrackerAbility());
+        }
+    }
+
+}
+
+namespace Abilities
+{
+    public class ThreatTrackerAbility : GenericAbility
+    {
+        private GenericShip threatTrackerTarget = null;
+        private List<GenericAction> threatTrackerActions = new List<GenericAction>();
+
+        public override void ActivateAbility()
+        {
+            GenericShip.OnMovementFinishGlobal += CheckThreatTrackerAbility;
+        }
+
+        public override void DeactivateAbility()
+        {
+            GenericShip.OnMovementFinishGlobal -= CheckThreatTrackerAbility;
+        }
+
+        public void ThreatTrackerCallback()
+        {
+            Selection.ChangeActiveShip(threatTrackerTarget);
+            Phases.FinishSubPhase(Phases.CurrentSubPhase.GetType());
+            Triggers.FinishTrigger();
+        }
+
+        private void CheckThreatTrackerAbility(GenericShip ship)
+        {
+            if (ship.Owner.PlayerNo != HostShip.Owner.PlayerNo)
+            {
+                threatTrackerTarget = ship;
+                RegisterAbilityTrigger(TriggerTypes.OnMovementFinish, AskThreatTrackerAbility);
+            }
+        }
+
+        private void AskThreatTrackerAbility(object sender, System.EventArgs e)
+        {
+            
+            ShotInfo shotInfo = new ShotInfo(HostShip, threatTrackerTarget, HostShip.PrimaryWeapon);
+            List<GenericAction> actionBar = HostShip.GetActionsFromActionBar();
+            List<GenericAction> freeActions = new List<GenericAction>() { new ActionsList.BoostAction(), new ActionsList.BarrelRollAction() };
+            threatTrackerActions.Clear();
+            freeActions.ForEach(delegate (GenericAction action)
+            {
+                if (actionBar.Exists(barAction => barAction.GetType() == action.GetType()))
+                {
+                    threatTrackerActions.Add(action);
+                }
+            });
+
+            if (threatTrackerActions.Count > 0 && shotInfo.InArc && shotInfo.Range <= 2)
+            {
+                AskToUseAbility(NeverUseByDefault, PerformThreatTracker);
+            }
+            else
+            {
+                Triggers.FinishTrigger();
+            }
+        }
+
+        private void PerformThreatTracker(object sender, EventArgs e)
+        {
+            GenericShip originalSelectedShip = Selection.ThisShip;
+            Selection.ChangeActiveShip(HostShip);
+            HostShip.AskPerformFreeAction(
+                threatTrackerActions,
+                ThreatTrackerCallback
+            );
+        }
+    }
+}

--- a/Assets/Scripts/Model/Upgrades/Tech/ThreatTracker.cs.meta
+++ b/Assets/Scripts/Model/Upgrades/Tech/ThreatTracker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b6107ef68c94a40e095e6365d06946d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Right now, it offers the ability to use the Threat Tracker and then displays an error if no actions are available (due to already being used.) Should it be altered to conditionally ask to use Threat Tracker only if there are available actions?