### PR TITLE
Barrel roll UI mobile bug fixes

### DIFF
--- a/Assets/Scripts/Model/Actions/ActionsList/BarrelRollAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/BarrelRollAction.cs
@@ -45,6 +45,8 @@ namespace SubPhases
 
     public class BarrelRollPlanningSubPhase : GenericSubPhase
     {
+        public override List<GameCommandTypes> AllowedGameCommandTypes { get { return new List<GameCommandTypes>() { GameCommandTypes.PressNext }; } }
+
         bool useMobileControls;
 
         List<Actions.BarrelRollTemplates> availableTemplates = new List<Actions.BarrelRollTemplates>();
@@ -190,6 +192,7 @@ namespace SubPhases
                     -0.5f * TheShip.ShipBase.SHIPSTAND_SIZE,
                     ProcessTemplatePositionSlider
                 );
+                IsReadyForCommands = true;
             }
         }
 

--- a/Assets/Scripts/Model/Actions/ActionsList/BarrelRollAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/BarrelRollAction.cs
@@ -406,9 +406,12 @@ namespace SubPhases
 
         public override void ProcessClick()
         {
-            StopDrag();
+            if (RuleSet.Instance is FirstEdition)
+            {
+                StopDrag();
 
-            if (!useMobileControls) ConfirmPosition();
+                if (!useMobileControls) ConfirmPosition();
+            }
         }
 
         private void ConfirmPosition()
@@ -510,22 +513,14 @@ namespace SubPhases
         {
             bool isFinished = false;
 
-            updatesCount++;
-
-            if (updatesCount == 3)
+            if (updatesCount > 1)
             {
-                // Collision check complete
                 GetResults();
                 isFinished = true;
             }
-            else if (updatesCount > 3) {
-                // For some reason on mobile, when the previous case causes this to return true,
-                // ShipMovementScript.UpdateSubscribedFuncs() doesn't actually remove this function
-                // from its subscription list. It calls FuncsToUpdate.Remove(func), but after that
-                // func is still in FuncsToUpdate somehow
-
-                // So we return true again, and this time it will actually get removed
-                isFinished = true;
+            else
+            {
+                updatesCount++;
             }
 
             return isFinished;

--- a/Assets/Scripts/Model/Actions/ActionsList/BarrelRollAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/BarrelRollAction.cs
@@ -510,14 +510,22 @@ namespace SubPhases
         {
             bool isFinished = false;
 
-            if (updatesCount > 1)
+            updatesCount++;
+
+            if (updatesCount == 3)
             {
+                // Collision check complete
                 GetResults();
                 isFinished = true;
             }
-            else
-            {
-                updatesCount++;
+            else if (updatesCount > 3) {
+                // For some reason on mobile, when the previous case causes this to return true,
+                // ShipMovementScript.UpdateSubscribedFuncs() doesn't actually remove this function
+                // from its subscription list. It calls FuncsToUpdate.Remove(func), but after that
+                // func is still in FuncsToUpdate somehow
+
+                // So we return true again, and this time it will actually get removed
+                isFinished = true;
             }
 
             return isFinished;


### PR DESCRIPTION
Fixes #1125, as well as another bug where barrel rolls on mobile on first edition wouldn't progress past the first slider when you clicked next.

The issue causing #1125 is really weird; the root issue appears to be List.Remove() not working in this specific case on mobile platforms, which seems very strange.

In more detail:
For some reason on mobile, when the UpdateColisionDetection function returns true, ShipMovementScript.UpdateSubscribedFuncs() doesn't actually remove theUpdateColisionDetection function from its subscription list. It calls FuncsToUpdate.Remove() on the function, but after that the function is still in the list somehow.

So to fix that we simply return true again the next time UpdateColisionDetection is called, and that time it actually gets removed.