### PR TITLE
Don't show frustum errors to the user, since the OS causes them on iOS

### DIFF
--- a/Assets/Scripts/Global/Model/Console/Console.cs
+++ b/Assets/Scripts/Global/Model/Console/Console.cs
@@ -142,7 +142,9 @@ public partial class Console : MonoBehaviour {
 
     private bool IsHiddenError(string text)
     {
-        if ((text == "ClientDisconnected due to error: Timeout") || (text == "ServerDisconnected due to error: Timeout")) return true;
+        if ((text == "ClientDisconnected due to error: Timeout") ||
+            (text == "ServerDisconnected due to error: Timeout") ||
+            text.StartsWith("Screen position out of view Frustrum")) return true;
 
         return false;
     }

--- a/Assets/Scripts/Global/Model/Console/Console.cs
+++ b/Assets/Scripts/Global/Model/Console/Console.cs
@@ -144,7 +144,7 @@ public partial class Console : MonoBehaviour {
     {
         if ((text == "ClientDisconnected due to error: Timeout") ||
             (text == "ServerDisconnected due to error: Timeout") ||
-            text.StartsWith("Screen position out of view Frustrum")) return true;
+            text.StartsWith("Screen position out of view frustum")) return true;
 
         return false;
     }


### PR DESCRIPTION
On iOS, interacting with some system UI elements, like dragging from the bottom edge of the screen up to open the control center or switching between apps, causes "Screen position out of view frustum" errors in Fly Casual when the app tries to parse coordinates that iOS apparently gives us which are very very offscreen. (~millions + of pixels offscreen)

This branch addresses that by just not showing those errors. If we think we might get Frustrum errors we do want to report as well, we could instead add a check for if the coordinates are onscreen whenever we raycast from a touch coordinate, but this approach is easier if we're not worried about that. :)