### PR TITLE
SE Advanced SLAM

### DIFF
--- a/Assets/Scripts/Model/Actions/ActionsList/GenericAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/GenericAction.cs
@@ -156,6 +156,16 @@ namespace ActionsList
             return result;
         }
 
+        public GenericAction AsRedAction
+        {
+            get
+            {
+                var redAction = (GenericAction)MemberwiseClone();
+                redAction.IsRed = true;
+                return redAction;
+            }
+        }
+
     }
 
 }

--- a/Assets/Scripts/Model/Upgrades/Modifications/AdvancedSlam.cs
+++ b/Assets/Scripts/Model/Upgrades/Modifications/AdvancedSlam.cs
@@ -4,10 +4,12 @@ using ActionsList;
 using Abilities;
 using System.Collections.Generic;
 using System.Linq;
+using RuleSets;
+using System;
 
 namespace UpgradesList
 {
-    public class AdvancedSlam : GenericUpgrade
+    public class AdvancedSlam : GenericUpgrade, ISecondEditionUpgrade
     {
         public AdvancedSlam() : base()
         {
@@ -16,6 +18,26 @@ namespace UpgradesList
             Cost = 2;
 
             UpgradeAbilities.Add(new AdvancedSlamAbility());
+        }
+
+        public void AdaptUpgradeToSecondEdition()
+        {
+            Cost = 3;
+            UpgradeAbilities.Clear();
+            UpgradeAbilities.Add(new Abilities.SecondEdition.AdvancedSlamAbility());
+            SEImageNumber = 69;            
+        }
+
+        public override bool IsAllowedForShip(GenericShip ship)
+        {
+            if (RuleSet.Instance is SecondEdition)
+            {
+                return ship.ActionBar.HasAction(typeof(SlamAction));
+            }
+            else
+            {
+                return true;
+            }
         }
     }
 }
@@ -64,12 +86,30 @@ namespace Abilities
             });
         }
 
-        private void PerfromFreeActionFromUpgradeBar(object sender, System.EventArgs e)
+        protected virtual void PerfromFreeActionFromUpgradeBar(object sender, System.EventArgs e)
         {
             List<GenericAction> actions = HostShip.GetAvailableActions();
             List<GenericAction> actionBarActions = actions.Where(n => n.IsInActionBar).ToList();
 
             Selection.ThisShip.AskPerformFreeAction(actionBarActions, Triggers.FinishTrigger);
+        }
+
+    }
+}
+
+namespace Abilities.SecondEdition
+{
+    public class AdvancedSlamAbility : Abilities.AdvancedSlamAbility
+    {
+        protected override void PerfromFreeActionFromUpgradeBar(object sender, EventArgs e)
+        {
+            List<GenericAction> actions = HostShip.GetAvailableActions();
+            List<GenericAction> whiteActionBarActionsAsRed = actions
+                .Where(n => n.IsInActionBar && !n.IsRed)                
+                .Select(n => n.AsRedAction)
+                .ToList();            
+
+            Selection.ThisShip.AskPerformFreeAction(whiteActionBarActionsAsRed, Triggers.FinishTrigger);
         }
     }
 }


### PR DESCRIPTION
Inherits from FE Advanced SLAM.
I had to add a clone generating property to GenericAction to obtain red clones of white actions, because altering the actions from the bar had the effect of turning the actions in the bar red.