### PR TITLE
BBs should not spend charge when ability is not used

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Astromech/BBAstromech.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Astromech/BBAstromech.cs
@@ -51,16 +51,24 @@ namespace Abilities.SecondEdition
 
         private void AskPerformAction(object sender, EventArgs e)
         {
+            HostShip.BeforeFreeActionIsPerformed += SpendCharge;
+
             HostShip.AskPerformFreeAction(
                 AbilityActions,
-                SpendCharge
+                CleanUp
             );
         }
 
-        private void SpendCharge()
+        private void SpendCharge(GenericAction action)
         {
+            HostShip.BeforeFreeActionIsPerformed -= SpendCharge;
             Sounds.PlayShipSound("BB-8-Sound");
             HostUpgrade.State.SpendCharge();
+        }
+
+        private void CleanUp()
+        {
+            HostShip.BeforeFreeActionIsPerformed -= SpendCharge;
             Triggers.FinishTrigger();
         }
     }


### PR DESCRIPTION
It works now, but I think this code is a bit clunky (used the same code as Vader). It would be better if the callback from AskPerformFreeAction had a parameter that says if the action was skipped or not.