### PR TITLE
Safety for null reference exception

### DIFF
--- a/Assets/Scripts/Model/Board/Info/ShotInfoArc.cs
+++ b/Assets/Scripts/Model/Board/Info/ShotInfoArc.cs
@@ -20,13 +20,22 @@ namespace BoardTools
         public ShotInfoArc(GenericShip ship1, GenericShip ship2, GenericArc arc) : base(ship1, ship2)
         {
             Arc = arc;
-
             CheckRange();
         }
 
         private void CheckRange()
         {
-            FindNearestDistances(Ship1.ShipBase.GetGlobalPoints(Arc.Edges));
+            if (Ship1 == null || Ship1.ShipBase == null) {
+                // Debug.LogError("Ship1 or Ship1.ShipBase is null");
+                return;
+            }
+            List<Vector3> globalPoints = Ship1.ShipBase.GetGlobalPoints(Arc.Edges);
+            if (globalPoints.Count > 0) {
+                FindNearestDistances(Ship1.ShipBase.GetGlobalPoints(Arc.Edges));
+            } else {
+                // Debug.LogError("No ship global points");
+                return;
+            }
             TryFindPerpendicularDistanceA();
             TryFindPerpendicularDistanceB();
             SetFinalMinDistance();

--- a/Assets/Scripts/Model/Content/Core/Ship/ShipBases/GenericShipBase.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/ShipBases/GenericShipBase.cs
@@ -201,7 +201,12 @@ namespace Ship
             List<Vector3> globalPoints = new List<Vector3>();
             foreach (var localPoint in localPoints)
             {
-                globalPoints.Add(GetGlobalPoint(localPoint));
+                try {
+                    globalPoints.Add(GetGlobalPoint(localPoint));
+                } catch (NullReferenceException e) {
+                    // Debug.LogError("Null Reference Error");
+                    // Debug.LogError(e.Message);
+                }
             }
             return globalPoints;
         }


### PR DESCRIPTION
The game sometimes generates a NullReferenceException when checking ShotInfoArc. One situation I have been able to replicate the bug is when A Jakku Gunrunner fires upon a ship and the game checks for Drea Renthal's ability. This causes a NullReferenceException that prevents the Attack Dice Roll Check from continuing, making the game unplayable. Specifically, GenericShipBase.GetGlobalPoint generates the NullReference, and the console gives an error saying that one of the references has been removed or disposed.

This does not necessarily solve the cause of the NullReferenceException, but it does prevent the user from having to restart the game.