### PR TITLE
Fixed Jake Farrell ability

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/RZ1AWing/JakeFarrell.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/RZ1AWing/JakeFarrell.cs
@@ -50,9 +50,6 @@ namespace Abilities.SecondEdition
         {
             if (action is BoostAction || action is BarrelRollAction)
             {
-                if (IsAbilityUsed) return;
-                IsAbilityUsed = true;
-
                 RegisterAbilityTrigger(TriggerTypes.OnActionIsPerformed, SelectTargetForJakeFarrellAbility);
             }
         }
@@ -72,10 +69,17 @@ namespace Abilities.SecondEdition
 
         private void GrantFreeFocusAction()
         {
+            Selection.ThisShip = TargetShip;
             TargetShip.AskPerformFreeAction(
                 new FocusAction() { HostShip = TargetShip },
-                SelectShipSubPhase.FinishSelection
+                AfterFreeFocusAction
             );
+        }
+
+        private void AfterFreeFocusAction()
+        {
+            Selection.ThisShip = HostShip;
+            SelectShipSubPhase.FinishSelection();
         }
 
         private bool FilterTargets(GenericShip ship)


### PR DESCRIPTION
Jake Farrell was unusable for ships other than himself (error message, Cannot perform free actions)
- Selection.ThisShip now changes to TargetShip, allowing other ships to receive his ability
- Removed check to see if ability is used, since it can be used once per action (as per FFG reference example of Jake Farrell using his ability twice in one move)