### PR TITLE
Fixed restriction for Daredevil. 

### DIFF
--- a/Assets/Scripts/Model/Content/Core/Upgrade/UpgradeCardRestrictions.cs
+++ b/Assets/Scripts/Model/Content/Core/Upgrade/UpgradeCardRestrictions.cs
@@ -65,18 +65,20 @@ namespace Upgrade
 
     public class ActionBarRestriction : UpgradeCardRestriction
     {
-        public ActionInfo Action { get; private set; }
+        public Type ActionType { get; private set; }
+        public ActionColor? ActionColor { get; private set; }
 
-        public ActionBarRestriction(ActionInfo action)
+        public ActionBarRestriction(Type actionType, ActionColor? color = null)
         {
-            Action = action;
+            ActionType = actionType;
+            ActionColor = color;
         }
 
         public override bool IsAllowedForShip(GenericShip ship)
         {
             return ship.ShipInfo.ActionIcons.Actions.Any(a => 
-                a.ActionType == Action.ActionType
-                && ((a.Color == Action.Color) || Action.Color == ActionColor.White)
+                a.ActionType == ActionType
+                && ((a.Color == ActionColor) || ActionColor == null)
             );
         }
     }

--- a/Assets/Scripts/Model/Content/FirstEdition/Upgrades/Modification/Autothrusters.cs
+++ b/Assets/Scripts/Model/Content/FirstEdition/Upgrades/Modification/Autothrusters.cs
@@ -15,7 +15,7 @@ namespace UpgradesList.FirstEdition
                 UpgradeType.Modification,
                 cost: 2,
                 abilityType: typeof(Abilities.FirstEdition.AutothrustersAbility),
-                restriction: new ActionBarRestriction(new ActionInfo(typeof(BoostAction)))
+                restriction: new ActionBarRestriction(typeof(BoostAction))
             );
         }
 

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/CienaRee.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/CienaRee.cs
@@ -20,7 +20,7 @@ namespace UpgradesList.SecondEdition
                 isLimited: true,
                 restrictions: new UpgradeCardRestrictions(
                     new FactionRestriction(Faction.Imperial),
-                    new ActionBarRestriction(new ActionInfo(typeof(CoordinateAction)))
+                    new ActionBarRestriction(typeof(CoordinateAction))
                 ),
                 abilityType: typeof(Abilities.SecondEdition.CienaReeCrewAbility),
                 seImageNumber: 111

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/GrandMoffTarkin.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/GrandMoffTarkin.cs
@@ -21,7 +21,7 @@ namespace UpgradesList.SecondEdition
                 isLimited: true,                
                 restrictions: new UpgradeCardRestrictions(
                     new FactionRestriction(Faction.Imperial), 
-                    new ActionBarRestriction(new ActionInfo(typeof(TargetLockAction)))
+                    new ActionBarRestriction(typeof(TargetLockAction))
                     ),
                 abilityType: typeof(Abilities.SecondEdition.GrandMoffTarkinAbility),
                 seImageNumber: 117,

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/TacticalOfficer.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/TacticalOfficer.cs
@@ -16,7 +16,7 @@ namespace UpgradesList.SecondEdition
                 UpgradeType.Crew,
                 cost: 2,
                 addAction: new ActionInfo(typeof(CoordinateAction)),
-                restriction: new ActionBarRestriction(new ActionInfo(typeof(CoordinateAction), ActionColor.Red)),
+                restriction: new ActionBarRestriction(typeof(CoordinateAction), ActionColor.Red),
                 seImageNumber: 48
             );
         }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/VeteranTurretGunner.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/VeteranTurretGunner.cs
@@ -16,7 +16,7 @@ namespace UpgradesList.SecondEdition
                 UpgradeType.Gunner,
                 cost: 6,
                 abilityType: typeof(Abilities.SecondEdition.VeteranTurretGunnerAbility),
-                restriction: new ActionBarRestriction(new ActionInfo(typeof(RotateArcAction))),
+                restriction: new ActionBarRestriction(typeof(RotateArcAction)),
                 seImageNumber: 52
             );
         }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/AdvancedSlam.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/AdvancedSlam.cs
@@ -16,7 +16,7 @@ namespace UpgradesList.SecondEdition
                 UpgradeType.Modification,
                 cost: 3,
                 abilityType: typeof(Abilities.SecondEdition.AdvancedSlamAbility),
-                restriction: new ActionBarRestriction(new ActionInfo(typeof(SlamAction))),
+                restriction: new ActionBarRestriction(typeof(SlamAction)),
                 seImageNumber: 69
             );
         }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/EngineUpgrade.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Modification/EngineUpgrade.cs
@@ -14,7 +14,7 @@ namespace UpgradesList.SecondEdition
                 "Engine Upgrade",
                 UpgradeType.Modification,
                 cost: 4,
-                restriction: new ActionBarRestriction(new ActionInfo(typeof(BoostAction), ActionColor.Red)),
+                restriction: new ActionBarRestriction(typeof(BoostAction), ActionColor.Red),
                 addAction: new ActionInfo(typeof(BoostAction)),
                 seImageNumber: 72
             );

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/Daredevil.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/Daredevil.cs
@@ -18,7 +18,7 @@ namespace UpgradesList.SecondEdition
                 abilityType: typeof(Abilities.SecondEdition.DareDevilAbility),
                 restrictions: new UpgradeCardRestrictions(
                     new BaseSizeRestriction(BaseSize.Small),
-                    new ActionBarRestriction(new ActionInfo(typeof(BoostAction), ActionColor.Red))
+                    new ActionBarRestriction(typeof(BoostAction), ActionColor.White)
                 ),
                 seImageNumber: 2
             );

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/ExpertHandling.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/ExpertHandling.cs
@@ -14,7 +14,7 @@ namespace UpgradesList.SecondEdition
                 "Expert Handling",
                 UpgradeType.Talent,
                 cost: 2,
-                restriction: new ActionBarRestriction(new ActionInfo(typeof(BarrelRollAction), ActionColor.Red)),
+                restriction: new ActionBarRestriction(typeof(BarrelRollAction), ActionColor.Red),
                 addAction: new ActionInfo(typeof(BarrelRollAction)),
                 seImageNumber: 5
             );

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/SaturationSalvo.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/SaturationSalvo.cs
@@ -16,7 +16,7 @@ namespace UpgradesList.SecondEdition
                 UpgradeType.Talent,
                 cost: 6,
                 abilityType: typeof(Abilities.SecondEdition.SaturationSalvoAbility),
-                restriction: new ActionBarRestriction(new ActionInfo(typeof(ReloadAction))),
+                restriction: new ActionBarRestriction(typeof(ReloadAction)),
                 seImageNumber: 14
             );
         }        


### PR DESCRIPTION
Also changed ActionBarRestriction so it can differentiate between cards that require white action (Daredevil) and cards that don't require a specific color (Ciena Ree)

Fixes #1496 