### PR TITLE
Fix NullPointerException for Muse

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIEFoFighter/Muse.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIEFoFighter/Muse.cs
@@ -67,6 +67,7 @@ namespace Abilities.SecondEdition
 
         protected bool FilterTargetsOfAbility(GenericShip ship)
         {
+            Selection.ThisShip = HostShip;
             return FilterByTargetType(
                 ship, new List<TargetTypes>() { TargetTypes.This, TargetTypes.OtherFriendly })
                 && FilterTargetsByRange(ship, 0, 1);


### PR DESCRIPTION
Selection.ThisShip is null during Muse ability activation, causing NullPointerException during filtering for targets.