### PR TITLE
Fixed incorrect deactivation of triggers in 2nd edition

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/BTLA4YWing/DreaRenthal.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/BTLA4YWing/DreaRenthal.cs
@@ -39,7 +39,7 @@ namespace Abilities.SecondEdition
 
         public override void DeactivateAbility()
         {
-            GenericShip.OnGenerateDiceModificationsGlobal += AddDreaRenthalAbility;
+            GenericShip.OnGenerateDiceModificationsGlobal -= AddDreaRenthalAbility;
         }
 
         private void AddDreaRenthalAbility(GenericShip ship)

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/KihraxzFighter/CaptainJostero.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/KihraxzFighter/CaptainJostero.cs
@@ -37,7 +37,7 @@ namespace Abilities.SecondEdition
 
         public override void DeactivateAbility()
         {
-            GenericShip.OnDamageInstanceResolvedGlobal += CheckJosteroAbility;
+            GenericShip.OnDamageInstanceResolvedGlobal -= CheckJosteroAbility;
         }
 
         private void CheckJosteroAbility(GenericShip damaged, DamageSourceEventArgs damage)

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIEAdvancedX1/ZertikStrom.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIEAdvancedX1/ZertikStrom.cs
@@ -38,7 +38,7 @@ namespace Abilities.SecondEdition
 
         public override void DeactivateAbility()
         {
-            Phases.Events.OnEndPhaseStart_Triggers += UseZertikStromAbility;
+            Phases.Events.OnEndPhaseStart_Triggers -= UseZertikStromAbility;
         }
 
         private void UseZertikStromAbility()

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/UnkarPlutt.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/UnkarPlutt.cs
@@ -34,7 +34,7 @@ namespace Abilities.SecondEdition
 
         public override void DeactivateAbility()
         {
-            HostShip.OnMovementFinishUnsuccessfully += RegisterAbility;
+            HostShip.OnMovementFinishUnsuccessfully -= RegisterAbility;
         }
 
         private void RegisterAbility(GenericShip ship)

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Force/Sense.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Force/Sense.cs
@@ -35,7 +35,7 @@ namespace Abilities.SecondEdition
 
         public override void DeactivateAbility()
         {
-            HostShip.OnSystemsAbilityActivation += RegisterAbilityTriggerByShip;
+            HostShip.OnSystemsAbilityActivation -= RegisterAbilityTriggerByShip;
         }
 
         private void RegisterAbilityTriggerByShip(GenericShip ship)

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Title/Dauntless.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Title/Dauntless.cs
@@ -34,7 +34,7 @@ namespace Abilities.SecondEdition
 
         public override void DeactivateAbility()
         {
-            HostShip.OnMovementFinishUnsuccessfully += RegisterAbility;
+            HostShip.OnMovementFinishUnsuccessfully -= RegisterAbility;
         }
 
         private void RegisterAbility(GenericShip ship)


### PR DESCRIPTION
After running into a crash after killing Drea, I went and looked at the code, and I think `DeactivateAbility()` was called incorrectly.  I then went and reviewed every second edition ability and found a few more:

- Drea
- Captain Jostero
- Zertik Strom
- Unkar Plutt
- Sense
- Dauntless
