### PR TITLE
Added: Energy-Shell Charges

### DIFF
--- a/Assets/Scripts/Model/Actions/ActionsList/ReloadAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/ReloadAction.cs
@@ -95,7 +95,7 @@ namespace ActionsList
             subphase.Start();
         }
 
-        private static void AssignTokenAndFinish()
+        protected static void AssignTokenAndFinish()
         {
             Selection.ThisShip.Tokens.AssignToken(typeof(WeaponsDisabledToken), Phases.CurrentSubPhase.CallBack);
         }

--- a/Assets/Scripts/Model/Content/Core/Upgrade/SpecialWeapon/GenericSpecialWeapon.cs
+++ b/Assets/Scripts/Model/Content/Core/Upgrade/SpecialWeapon/GenericSpecialWeapon.cs
@@ -82,9 +82,9 @@ namespace Upgrade
                 if (waysToPay.Count == 0) return false;
             }
 
-            if (WeaponInfo.RequiresToken == typeof(FocusToken))
+            if (WeaponInfo.RequiresToken != null)
             {
-                if (!HostShip.Tokens.HasToken(typeof(FocusToken))) return false;
+                if (!HostShip.Tokens.HasToken(WeaponInfo.RequiresToken)) return false;
             }
 
             return result;

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Missile/EnergyShellCharges.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Missile/EnergyShellCharges.cs
@@ -1,0 +1,114 @@
+﻿using ActionsList;
+using Arcs;
+using Ship;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Tokens;
+using Upgrade;
+
+namespace UpgradesList.SecondEdition
+{
+    public class EnergyShellCharges : GenericSpecialWeapon
+    {
+        public EnergyShellCharges() : base()
+        {
+            UpgradeInfo = new UpgradeCardInfo(
+                "Energy-Shell Charges",
+                UpgradeType.Missile,
+                cost: 4,
+                weaponInfo: new SpecialWeaponInfo(
+                    attackValue: 3,
+                    minRange: 2,
+                    maxRange: 3,
+                    requiresToken: typeof(CalculateToken),
+                    charges: 1,
+                    arc: ArcType.Front
+                ),
+               restrictions: new UpgradeCardRestrictions(new ActionBarRestriction(typeof(CalculateAction)), new FactionRestriction(Faction.Separatists)),
+               abilityType: typeof(Abilities.SecondEdition.EnergyShellChargesAbility)
+            );
+            ImageUrl = "https://sb-cdn.fantasyflightgames.com/card_images/en/4b6213e5ed13735bb381df08bdd1398d.png";
+        }
+    }
+}
+
+namespace Abilities.SecondEdition
+{
+    public class EnergyShellChargesAbility : GenericAbility
+    {
+        public override void ActivateAbility()
+        {
+            AddDiceModification(
+                "Spend Calculate for Eye to Crit",
+                IsAvailable,
+                GetAiPriority,
+                DiceModificationType.Change,
+                1,
+                payAbilityCost: PayAbilityCost,                
+                sidesCanBeSelected: new List<DieSide> { DieSide.Focus},
+                sideCanBeChangedTo: DieSide.Crit
+            );
+            HostShip.OnGenerateActions += AddEnergyShellChargesAction;
+        }
+
+        private bool IsAvailable()
+        {
+            return Combat.ChosenWeapon == HostUpgrade                
+                && HostShip.Tokens.CountTokensByType<CalculateToken>() > 0
+                && Combat.AttackStep == CombatStep.Attack
+                && Combat.DiceRollAttack.Focuses > 0;
+        }
+
+        private int GetAiPriority()
+        {
+            return 42; // Just above Calculate's default priority
+        }
+                
+        private void PayAbilityCost(Action<bool> callback)
+        {
+            if (HostShip.Tokens.HasToken<CalculateToken>())
+            {
+                HostShip.Tokens.SpendToken(
+                    typeof(CalculateToken),
+                    () => callback(true)
+                );
+            }
+            else
+            {
+                callback(false);
+            }
+        }
+
+        public override void DeactivateAbility()
+        {
+            RemoveDiceModification();
+            HostShip.OnGenerateActions -= AddEnergyShellChargesAction;
+        }
+
+        protected void AddEnergyShellChargesAction(GenericShip ship)
+        {
+            if (HostUpgrade.State.Charges <= 0)
+            {
+                ship.AddAvailableAction(new ReloadEnergyShellChargesAction()
+                {
+                    ImageUrl = HostUpgrade.ImageUrl,
+                    HostShip = HostShip,
+                    Source = HostUpgrade,
+                    Name = "Reload Energy-Shell Charges"
+                });
+            }
+        }
+
+        protected class ReloadEnergyShellChargesAction : ReloadAction
+        {
+            public override void ActionTake()
+            {
+                Source.State.RestoreCharge();
+                Messages.ShowInfo($"Reload: One charge of \"{Source.UpgradeInfo.Name}\" is restored.  {HostShip.PilotInfo.PilotName} gains a Disarmed token.");
+                AssignTokenAndFinish();
+            }
+        }
+
+    }
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Missile/EnergyShellCharges.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Missile/EnergyShellCharges.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f11126cf5242107479412a08fdffbc59
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fixed: GenericSpecialWeapon will spend whatever required token is specified for the attack, instead of just Lock and Focus tokens.