### PR TITLE
Darth Maul should spend Force before the attack begins

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/SithInfiltrator/DarthMaul.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/SithInfiltrator/DarthMaul.cs
@@ -92,7 +92,8 @@ namespace Abilities.SecondEdition
                     IsAllowedAttack,
                     HostName,
                     "You may spend 2 force to perform a bonus primary attack" + (FirstAttackMissed ? "" : " against a different target"),
-                    HostUpgrade
+                    HostUpgrade,
+                    payAttackCost: PayAttackCost
                 );
             }
             else
@@ -102,8 +103,20 @@ namespace Abilities.SecondEdition
             }
         }
 
+        private void PayAttackCost(Action callback)
+        {
+            HostShip.State.Force -= 2;
+            callback();
+        }
+
         private bool IsAllowedAttack(GenericShip defender, IShipWeapon weapon, bool isSilent)
         {
+            if (HostShip.State.Force < 2)
+            {
+                if (!isSilent) Messages.ShowError("Your must have at least 2 Force tokens to perform this attack.");
+                return false;
+            }
+
             if (weapon.WeaponType != WeaponTypes.PrimaryWeapon)
             {
                 if (!isSilent) Messages.ShowError("Your bonus attack must be a primary weapon attack.");
@@ -122,11 +135,7 @@ namespace Abilities.SecondEdition
 
         private void FinishAdditionalAttack()
         {
-            if (HostShip.IsAttackPerformed)
-            {
-                HostShip.State.Force -= 2;
-            }
-            else
+            if (!HostShip.IsAttackPerformed)
             {
                 // If attack is skipped, set this flag, otherwise regular attack can be performed second time
                 HostShip.IsAttackPerformed = true;

--- a/Assets/Scripts/Model/Phases/SubPhases/Temporary/SelectTargetForAttackSubPhase.cs
+++ b/Assets/Scripts/Model/Phases/SubPhases/Temporary/SelectTargetForAttackSubPhase.cs
@@ -81,6 +81,7 @@ namespace SubPhases
             HideSubphaseDescription();
 
             Combat.ExtraAttackFilter = null;
+            Combat.PayExtraAttackCost = null;
 
             Phases.CurrentSubPhase = PreviousSubPhase;
         }


### PR DESCRIPTION
Otherwise he could spend the force on modifying the dice

Added payAttackCost parameter to Combat.StartSelectAttackTarget() to make it easy to add a custom cost for the attack

Fixes #1714