### PR TITLE
Fix Second Edition Miranda Doni ability

### DIFF
--- a/Assets/Scripts/Model/Content/FirstEdition/Pilots/KWing/MirandaDoni.cs
+++ b/Assets/Scripts/Model/Content/FirstEdition/Pilots/KWing/MirandaDoni.cs
@@ -38,7 +38,7 @@ namespace Abilities.FirstEdition
             Phases.Events.OnRoundEnd -= ClearAbility;
         }
 
-        private void CheckConditions()
+        protected virtual void CheckConditions()
         {
             if (!IsAbilityUsed)
             {

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/BTLS8KWing/MirandaDoni.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/BTLS8KWing/MirandaDoni.cs
@@ -27,6 +27,14 @@ namespace Abilities.SecondEdition
 {
     public class MirandaDoniAbility : Abilities.FirstEdition.MirandaDoniAbility
     {
+        protected override void CheckConditions()
+        {
+            if (!IsAbilityUsed && Combat.ChosenWeapon.WeaponType == Ship.WeaponTypes.PrimaryWeapon)
+            {
+                RegisterAbilityTrigger(TriggerTypes.OnShotStart, StartQuestionSubphase);
+            }
+        }
+
         protected override void StartQuestionSubphase(object sender, System.EventArgs e)
         {
             MirandaDoniDecisionSubPhase selectMirandaDoniSubPhase = (MirandaDoniDecisionSubPhase)Phases.StartTemporarySubPhaseNew(


### PR DESCRIPTION
In Second Edition, Miranda's ability should only trigger for primary weapons: https://xwing-miniatures-second-edition.fandom.com/wiki/Miranda_Doni