### PR TITLE
update Wounded Pilot image

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/DamageDeck/WoundedPilot.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/DamageDeck/WoundedPilot.cs
@@ -14,7 +14,7 @@ namespace DamageDeckCardSE
         {
             Name = "Wounded Pilot";
             Type = CriticalCardType.Pilot;
-            ImageUrl = "https://i.imgur.com/GtW7OR5.png";
+            ImageUrl = "https://i.imgur.com/BIla4b2.jpg";
         }
 
         public override void ApplyEffect(object sender, EventArgs e)


### PR DESCRIPTION
The current image URL for Wounded Pilot states "After you perform an **attack**...", when it should be "After you perform an **action**..." (as per https://xwing-miniatures-second-edition.fandom.com/wiki/Damage_Cards).

This PR attempts to fix that by updating the image URL to point to https://i.imgur.com/BIla4b2.jpg, the image used by the [Wounded Pilot crit token](https://github.com/Sandrem/FlyCasual/blob/development/Assets/Scripts/Model/Tokens/CritToken.cs#L176-L182) (which has the correct wording).

Fixes #1874.

