### PR TITLE
Fix FE/SE Manaroo abilities

### DIFF
--- a/Assets/Scripts/Model/Content/FirstEdition/Pilots/JumpMaster5000/Manaroo.cs
+++ b/Assets/Scripts/Model/Content/FirstEdition/Pilots/JumpMaster5000/Manaroo.cs
@@ -32,6 +32,10 @@ namespace Abilities.FirstEdition
 {
     public abstract class ManarooCommonAbility : GenericAbility
     {
+        protected abstract int MinRange { get; }
+
+        protected abstract int MaxRange { get; }
+
         protected abstract List<Type> ReassignableTokenTypes { get; }
 
         protected abstract string SelectTargetMessage { get; }
@@ -42,6 +46,22 @@ namespace Abilities.FirstEdition
     //At the start of the Combat phase, you may assign all focus, evade, and target lock tokens assigned to you to another friendly ship at Range 1.
     public class ManarooAbility : ManarooCommonAbility
     {
+        protected override int MinRange
+        {
+            get
+            {
+                return 1;
+            }
+        }
+
+        protected override int MaxRange
+        {
+            get
+            {
+                return 1;
+            }
+        }
+
         protected override List<Type> ReassignableTokenTypes
         {
             get
@@ -88,7 +108,7 @@ namespace Abilities.FirstEdition
         {
             if (HostShip.Owner.Ships.Count == 1) return;
 
-            if (CountFriendlyShipsInRange(1, 1) == 0) return;
+            if (CountFriendlyShipsInRange() == 0) return;
 
             RegisterAbilityTrigger(TriggerTypes.OnCombatPhaseStart, SelectTarget);
         }
@@ -106,9 +126,9 @@ namespace Abilities.FirstEdition
             );
         }
 
-        protected virtual bool FilterAbilityTargets(GenericShip ship)
+        private bool FilterAbilityTargets(GenericShip ship)
         {
-            return FilterByTargetType(ship, new List<TargetTypes>() { TargetTypes.OtherFriendly }) && FilterTargetsByRange(ship, 1, 1);
+            return FilterByTargetType(ship, new List<TargetTypes>() { TargetTypes.OtherFriendly }) && FilterTargetsByRange(ship, MinRange, MaxRange);
         }
 
         private int GetAiPriority(GenericShip ship)
@@ -162,9 +182,9 @@ namespace Abilities.FirstEdition
             return supportedToken;
         }
 
-        protected int CountFriendlyShipsInRange(int minRange, int maxRange)
+        protected int CountFriendlyShipsInRange()
         {
-            return BoardTools.Board.GetShipsAtRange(HostShip, new Vector2(minRange, maxRange), Team.Type.Friendly).Count;
+            return BoardTools.Board.GetShipsAtRange(HostShip, new Vector2(MinRange, MaxRange), Team.Type.Friendly).Count;
         }
     }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/JumpMaster5000/Manaroo.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/JumpMaster5000/Manaroo.cs
@@ -1,4 +1,9 @@
-﻿using Upgrade;
+﻿using Ship;
+using SubPhases;
+using System;
+using System.Collections.Generic;
+using Tokens;
+using Upgrade;
 
 namespace Ship
 {
@@ -13,12 +18,55 @@ namespace Ship
                     3,
                     47,
                     isLimited: true,
-                    abilityType: typeof(Abilities.FirstEdition.ManarooAbility),
+                    abilityType: typeof(Abilities.SecondEdition.ManarooAbility),
                     charges: 1,
                     extraUpgradeIcon: UpgradeType.Talent,
                     seImageNumber: 215
                 );
             }
+        }
+    }
+}
+
+namespace Abilities.SecondEdition
+{
+    //At the start of the Engagement Phase, you may choose a friendly ship at range 0-1. If you do, transfer all green tokens assigned to you to that ship.
+    public class ManarooAbility : Abilities.FirstEdition.ManarooAbility
+    {
+        protected override void CheckAbility()
+        {
+            if (HostShip.Owner.Ships.Count == 1) return;
+
+            if (CountFriendlyShipsInRange(0, 1) == 1) return;
+
+            RegisterAbilityTrigger(TriggerTypes.OnCombatPhaseStart, SelectTarget);
+        }
+
+        protected override string GetSelectTargetDescription()
+        {
+            return "Choose another friendly ship to assign all your green tokens to it";
+        }
+
+        protected override bool FilterAbilityTargets(GenericShip ship)
+        {
+            return FilterByTargetType(ship, new List<TargetTypes>() { TargetTypes.OtherFriendly }) && FilterTargetsByRange(ship, 0, 1);
+        }
+
+        protected override string GetReassignTokensFormatString()
+        {
+            return "{0}: all green tokens have been reassigned to {1}";
+        }
+
+        protected override List<Type> GetReassignableTokenTypes()
+        {
+            return new List<Type>()
+            {
+                typeof(CalculateToken),
+                typeof(EvadeToken),
+                typeof(FocusToken),
+                typeof(ReinforceForeToken),
+                typeof(ReinforceAftToken)
+            };
         }
     }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/JumpMaster5000/Manaroo.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/JumpMaster5000/Manaroo.cs
@@ -84,7 +84,7 @@ namespace Abilities.SecondEdition
         {
             if (HostShip.Owner.Ships.Count == 1) return;
 
-            //Skip if only 1 friendly ship in range, since Manaroo is always in range 0 of himself
+            //Skip if only 1 friendly ship in range, since Manaroo is always in range 0 of herself
             if (CountFriendlyShipsInRange() == 1) return;
 
             RegisterAbilityTrigger(TriggerTypes.OnCombatPhaseStart, SelectTarget);

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/JumpMaster5000/Manaroo.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/JumpMaster5000/Manaroo.cs
@@ -33,6 +33,22 @@ namespace Abilities.SecondEdition
     //At the start of the Engagement Phase, you may choose a friendly ship at range 0-1. If you do, transfer all green tokens assigned to you to that ship.
     public class ManarooAbility : Abilities.FirstEdition.ManarooAbility
     {
+        protected override int MinRange
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        protected override int MaxRange
+        {
+            get
+            {
+                return 1;
+            }
+        }
+
         protected override List<Type> ReassignableTokenTypes
         {
             get
@@ -68,14 +84,10 @@ namespace Abilities.SecondEdition
         {
             if (HostShip.Owner.Ships.Count == 1) return;
 
-            if (CountFriendlyShipsInRange(0, 1) == 1) return;
+            //Skip if only 1 friendly ship in range, since Manaroo is always in range 0 of himself
+            if (CountFriendlyShipsInRange() == 1) return;
 
             RegisterAbilityTrigger(TriggerTypes.OnCombatPhaseStart, SelectTarget);
-        }
-
-        protected override bool FilterAbilityTargets(GenericShip ship)
-        {
-            return FilterByTargetType(ship, new List<TargetTypes>() { TargetTypes.OtherFriendly }) && FilterTargetsByRange(ship, 0, 1);
         }
     }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/JumpMaster5000/Manaroo.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/JumpMaster5000/Manaroo.cs
@@ -33,6 +33,37 @@ namespace Abilities.SecondEdition
     //At the start of the Engagement Phase, you may choose a friendly ship at range 0-1. If you do, transfer all green tokens assigned to you to that ship.
     public class ManarooAbility : Abilities.FirstEdition.ManarooAbility
     {
+        protected override List<Type> ReassignableTokenTypes
+        {
+            get
+            {
+                return new List<Type>()
+                {
+                    typeof(CalculateToken),
+                    typeof(EvadeToken),
+                    typeof(FocusToken),
+                    typeof(ReinforceForeToken),
+                    typeof(ReinforceAftToken)
+                };
+            }
+        }
+
+        protected override string SelectTargetMessage
+        {
+            get
+            {
+                return "Choose another friendly ship to assign all your green tokens to it";
+            }
+        }
+
+        protected override string ReassignTokensMessage
+        {
+            get
+            {
+                return string.Format("{0}: all green tokens have been reassigned to {1}", HostShip.PilotInfo.PilotName, TargetShip.PilotInfo.PilotName);
+            }
+        }
+
         protected override void CheckAbility()
         {
             if (HostShip.Owner.Ships.Count == 1) return;
@@ -42,31 +73,9 @@ namespace Abilities.SecondEdition
             RegisterAbilityTrigger(TriggerTypes.OnCombatPhaseStart, SelectTarget);
         }
 
-        protected override string GetSelectTargetDescription()
-        {
-            return "Choose another friendly ship to assign all your green tokens to it";
-        }
-
         protected override bool FilterAbilityTargets(GenericShip ship)
         {
             return FilterByTargetType(ship, new List<TargetTypes>() { TargetTypes.OtherFriendly }) && FilterTargetsByRange(ship, 0, 1);
-        }
-
-        protected override string GetReassignTokensFormatString()
-        {
-            return "{0}: all green tokens have been reassigned to {1}";
-        }
-
-        protected override List<Type> GetReassignableTokenTypes()
-        {
-            return new List<Type>()
-            {
-                typeof(CalculateToken),
-                typeof(EvadeToken),
-                typeof(FocusToken),
-                typeof(ReinforceForeToken),
-                typeof(ReinforceAftToken)
-            };
         }
     }
 }


### PR DESCRIPTION
Fixes FE Manaroo ability (reassigns focus/evade/target locks, range 1) and SE Manaroo abilities (reassigns all green tokens, range 0-1).

@Sandrem I created `GetSelectTargetDescription`, `GetReassignTokensFormatString`, and `GetReassignableTokenTypes` as a work-around for not being able to create virtual static properties.  I'm still a C# beginner; if there's a better way to do this, let me know and I'll make the switch.

Fixes #1913 