### PR TITLE
Fix erroneous Disarm token for Corran Horn ability

### DIFF
--- a/Assets/Scripts/Model/Content/Core/Ship/GenericShipFlags.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/GenericShipFlags.cs
@@ -9,6 +9,7 @@ namespace Ship
         public bool IsSetupPerformed { get; set; }
         public bool IsManeuverPerformed { get; set; }
         public bool IsAttackPerformed { get; set; }
+        public bool IsAttackSkipped { get; set; }
         public bool IsActivatedDuringCombat { get; set; }
 
         public bool IsSkipsActionSubPhase { get; set; }

--- a/Assets/Scripts/Model/Content/FirstEdition/Pilots/EWing/CorranHorn.cs
+++ b/Assets/Scripts/Model/Content/FirstEdition/Pilots/EWing/CorranHorn.cs
@@ -59,7 +59,7 @@ namespace Abilities
         private void AfterExtraAttackSubPhase()
         {
             // "Weapons disabled" token is assigned only if attack was successfully performed
-            if (HostShip.IsAttackPerformed) Phases.Events.OnRoundStart += RegisterAssignWeaponsDisabledTrigger;
+            if (!HostShip.IsAttackSkipped) Phases.Events.OnRoundStart += RegisterAssignWeaponsDisabledTrigger;
 
             Triggers.FinishTrigger();
         }

--- a/Assets/Scripts/Model/Content/FirstEdition/Upgrades/Talent/SnapShot.cs
+++ b/Assets/Scripts/Model/Content/FirstEdition/Upgrades/Talent/SnapShot.cs
@@ -79,6 +79,7 @@ namespace Abilities.FirstEdition
             ClearIsAbilityUsedFlag();
             snapShotTarget = null;
             HostShip.IsAttackPerformed = false;
+            HostShip.IsAttackSkipped = false;
             HostShip.IsCannotAttackSecondTime = false;
 
             // TODOREVERT

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/HanSoloRebel.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/HanSoloRebel.cs
@@ -71,6 +71,7 @@ namespace Abilities.SecondEdition
 
             // Can attack as usual later
             HostShip.IsAttackPerformed = false;
+            HostShip.IsAttackSkipped = false;
 
             Triggers.FinishTrigger();
         }

--- a/Assets/Scripts/Model/Phases/SubPhases/Temporary/SelectTargetForAttackSubPhase.cs
+++ b/Assets/Scripts/Model/Phases/SubPhases/Temporary/SelectTargetForAttackSubPhase.cs
@@ -15,6 +15,7 @@ namespace SubPhases
         public override void Prepare()
         {
             Selection.ThisShip.IsAttackPerformed = false;
+            Selection.ThisShip.IsAttackSkipped = false;
             Combat.IsAttackAlreadyCalled = false;
 
             PrepareByParameters(
@@ -78,6 +79,7 @@ namespace SubPhases
         {
             UI.HideSkipButton();
             Selection.ThisShip.IsAttackPerformed = true;
+            Selection.ThisShip.IsAttackSkipped = true;
             CallBack();
         }
 

--- a/Assets/Scripts/Model/Rules/RulesList/EndPhaseCleanupRule.cs
+++ b/Assets/Scripts/Model/Rules/RulesList/EndPhaseCleanupRule.cs
@@ -76,6 +76,7 @@ namespace RulesList
         private void ClearShipFlags(GenericShip ship)
         {
             ship.IsAttackPerformed = false;
+            ship.IsAttackSkipped = false;
             ship.IsManeuverPerformed = false;
             ship.IsSkipsActionSubPhase = false;
             ship.IsBombAlreadyDropped = false;


### PR DESCRIPTION
It appears that the reported issue of Corran Horn getting a Disarm token even when his extra attack is skipped is due to `IsAttackPerformed` being set to true even when the extra attack is skipped (see https://github.com/Sandrem/FlyCasual/blob/development/Assets/Scripts/Model/Phases/SubPhases/Temporary/SelectTargetForAttackSubPhase.cs#L80).

This PR attempts to fix the Disarm token issue by adding a flag to track when an attack is skipped.

Fixes #1875 