### PR TITLE
July 2019 point update: Rebel Alliance

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/ARC170Starfighter/GarvenDreis.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/ARC170Starfighter/GarvenDreis.cs
@@ -15,7 +15,7 @@ namespace Ship
                 PilotInfo = new PilotCardInfo(
                     "Garven Dreis",
                     4,
-                    51,
+                    49,
                     isLimited: true,
                     abilityType: typeof(Abilities.SecondEdition.GarvenDreisAbility),
                     extraUpgradeIcon: UpgradeType.Talent,

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/ARC170Starfighter/Ibtisam.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/ARC170Starfighter/Ibtisam.cs
@@ -13,7 +13,7 @@ namespace Ship
                 PilotInfo = new PilotCardInfo(
                     "Ibtisam",
                     3,
-                    50,
+                    48,
                     isLimited: true,
                     abilityType: typeof(Abilities.FirstEdition.BraylenStrammAbility),
                     extraUpgradeIcon: UpgradeType.Talent,

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/ARC170Starfighter/SharaBey.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/ARC170Starfighter/SharaBey.cs
@@ -15,7 +15,7 @@ namespace Ship
                 PilotInfo = new PilotCardInfo(
                     "Shara Bey",
                     4,
-                    53,
+                    50,
                     isLimited: true,
                     abilityType: typeof(Abilities.SecondEdition.SharaBeyAbility),
                     extraUpgradeIcon: UpgradeType.Talent,

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/ASF01BWing/BraylenStramm.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/ASF01BWing/BraylenStramm.cs
@@ -14,7 +14,7 @@ namespace Ship
                 PilotInfo = new PilotCardInfo(
                     "Braylen Stramm",
                     4,
-                    47,
+                    51,
                     isLimited: true,
                     abilityType: typeof(BraylenStrammAbility),
                     extraUpgradeIcon: UpgradeType.Talent,

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/ASF01BWing/TenNumb.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/ASF01BWing/TenNumb.cs
@@ -15,7 +15,7 @@ namespace Ship
                 PilotInfo = new PilotCardInfo(
                     "Ten Numb",
                     4,
-                    46,
+                    48,
                     isLimited: true,
                     abilityType: typeof(TenNumbAbility),
                     extraUpgradeIcon: UpgradeType.Talent,

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/BTLA4YWing/DutchVander.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/BTLA4YWing/DutchVander.cs
@@ -21,7 +21,7 @@ namespace Ship
                 PilotInfo = new PilotCardInfo(
                     "\"Dutch\" Vander",
                     4,
-                    39,
+                    40,
                     isLimited: true,
                     abilityType: typeof(DutchVanderAbility),
                     extraUpgradeIcon: UpgradeType.Talent,

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/BTLS8KWing/EsegeTuketu.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/BTLS8KWing/EsegeTuketu.cs
@@ -16,7 +16,7 @@ namespace Ship
                 PilotInfo = new PilotCardInfo(
                     "Esege Tuketu",
                     3,
-                    47,
+                    45,
                     isLimited: true,
                     abilityType: typeof(Abilities.SecondEdition.EsegeTuketuAbility),
                     seImageNumber: 63

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/BTLS8KWing/MirandaDoni.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/BTLS8KWing/MirandaDoni.cs
@@ -13,7 +13,7 @@ namespace Ship
                 PilotInfo = new PilotCardInfo(
                     "Miranda Doni",
                     4,
-                    45,
+                    43,
                     isLimited: true,
                     abilityType: typeof(Abilities.SecondEdition.MirandaDoniAbility),
                     seImageNumber: 62

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/BTLS8KWing/WardenSquadronPilot.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/BTLS8KWing/WardenSquadronPilot.cs
@@ -14,7 +14,7 @@ namespace Ship
                 PilotInfo = new PilotCardInfo(
                     "Warden Squadron Pilot",
                     2,
-                    37,
+                    39,
                     seImageNumber: 64
                 );
             }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/EWing/KnaveSquadronEscort.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/EWing/KnaveSquadronEscort.cs
@@ -13,7 +13,7 @@ namespace Ship
                 PilotInfo = new PilotCardInfo(
                     "Knave Squadron Escort",
                     2,
-                    54,
+                    52,
                     seImageNumber: 53
                 );
             }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/EWing/RogueSquadronEscort.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/EWing/RogueSquadronEscort.cs
@@ -14,7 +14,7 @@ namespace Ship
                 PilotInfo = new PilotCardInfo(
                     "Rogue Squadron Escort",
                     4,
-                    56,
+                    54,
                     extraUpgradeIcon: UpgradeType.Talent,
                     seImageNumber: 52
                 );

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Hwk290LightFreighter/JanOrs.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Hwk290LightFreighter/JanOrs.cs
@@ -15,7 +15,7 @@ namespace Ship
                 PilotInfo = new PilotCardInfo(
                     "Jan Ors",
                     5,
-                    44,
+                    43,
                     isLimited: true,
                     abilityType: typeof(Abilities.SecondEdition.JanOrsAbility),
                     extraUpgradeIcon: UpgradeType.Talent,

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Hwk290LightFreighter/KyleKatarn.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Hwk290LightFreighter/KyleKatarn.cs
@@ -17,7 +17,7 @@ namespace Ship
                 PilotInfo = new PilotCardInfo(
                     "Kyle Katarn",
                     3,
-                    39,
+                    36,
                     isLimited: true,
                     abilityType: typeof(Abilities.SecondEdition.KyleKatarnAbility),
                     extraUpgradeIcon: UpgradeType.Talent,

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Hwk290LightFreighter/RebelScout.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Hwk290LightFreighter/RebelScout.cs
@@ -13,7 +13,7 @@ namespace Ship
                 PilotInfo = new PilotCardInfo(
                     "Rebel Scout",
                     2,
-                    33,
+                    30,
                     seImageNumber: 45
                 );
             }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Hwk290LightFreighter/RoarkGarnet.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Hwk290LightFreighter/RoarkGarnet.cs
@@ -17,7 +17,7 @@ namespace Ship
                 PilotInfo = new PilotCardInfo(
                     "Roark Garnet",
                     4,
-                    43,
+                    41,
                     isLimited: true,
                     abilityType: typeof(Abilities.SecondEdition.RoarkGarnetAbility),
                     extraUpgradeIcon: UpgradeType.Talent,

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/T65XWing/WedgeAntilles.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/T65XWing/WedgeAntilles.cs
@@ -13,7 +13,7 @@ namespace Ship
                 PilotInfo = new PilotCardInfo(
                     "Wedge Antilles",
                     6,
-                    52,
+                    55,
                     isLimited: true,
                     abilityType: typeof(Abilities.FirstEdition.WedgeAntillesAbility),
                     extraUpgradeIcon: UpgradeType.Talent,

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/UT60DUWing/CassianAndor.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/UT60DUWing/CassianAndor.cs
@@ -19,7 +19,7 @@ namespace Ship
                 PilotInfo = new PilotCardInfo(
                     "Cassian Andor",
                     3,
-                    47,
+                    51,
                     isLimited: true,
                     abilityType: typeof(CassianAndorAbility),
                     extraUpgradeIcon: UpgradeType.Talent,

--- a/Assets/Scripts/Model/Content/SecondEdition/Ships/ModifiedYT1300LightFreighter.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Ships/ModifiedYT1300LightFreighter.cs
@@ -20,7 +20,7 @@ namespace Ship.SecondEdition.ModifiedYT1300LightFreighter
 
             ShipInfo.UpgradeIcons.Upgrades.Add(UpgradeType.Missile);
             ShipInfo.UpgradeIcons.Upgrades.Add(UpgradeType.Gunner);
-            ShipInfo.UpgradeIcons.Upgrades.Add(UpgradeType.Illicit);
+            ShipInfo.UpgradeIcons.Upgrades.Add(UpgradeType.Modification);
 
             ShipInfo.ActionIcons.AddActions(new ActionInfo(typeof(RotateArcAction)));
             ShipInfo.ActionIcons.AddActions(new ActionInfo(typeof(BoostAction), ActionColor.Red));

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Astromech/R2D2.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Astromech/R2D2.cs
@@ -1,22 +1,37 @@
 ﻿using Upgrade;
 using UnityEngine;
+using Ship;
+using System.Collections.Generic;
 
 namespace UpgradesList.SecondEdition
 {
-    public class R2D2 : GenericUpgrade
+    public class R2D2 : GenericUpgrade, IVariableCost
     {
         public R2D2() : base()
         {
             UpgradeInfo = new UpgradeCardInfo(
                 "R2-D2",
                 UpgradeType.Astromech,
-                cost: 6,
+                cost: 4,
                 isLimited: true,
                 abilityType: typeof(Abilities.SecondEdition.R2AstromechAbility),
                 restriction: new FactionRestriction(Faction.Rebel),
                 charges: 3,
                 seImageNumber: 100
             );
+        }
+
+        public void UpdateCost(GenericShip ship)
+        {
+            Dictionary<int, int> agilityToCost = new Dictionary<int, int>()
+            {
+                {0, 4},
+                {1, 4},
+                {2, 5},
+                {3, 7}
+            };
+
+            UpgradeInfo.Cost = agilityToCost[ship.ShipInfo.Agility];
         }
     }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/LeiaOrgana.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/LeiaOrgana.cs
@@ -13,7 +13,7 @@ namespace UpgradesList.SecondEdition
             UpgradeInfo = new UpgradeCardInfo(
                 "Leia Organa",
                 UpgradeType.Crew,
-                cost: 2,
+                cost: 6,
                 isLimited: true,
                 restriction: new FactionRestriction(Faction.Rebel),
                 charges: 3,

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/R2D2.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/R2D2.cs
@@ -12,7 +12,7 @@ namespace UpgradesList.SecondEdition
             UpgradeInfo = new UpgradeCardInfo(
                 "R2-D2 (crew)",
                 UpgradeType.Crew,
-                cost: 8,
+                cost: 10,
                 isLimited: true,
                 restriction: new FactionRestriction(Faction.Rebel),
                 abilityType: typeof(Abilities.SecondEdition.R2D2CrewAbility),

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/SawGerrera.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/SawGerrera.cs
@@ -11,7 +11,7 @@ namespace UpgradesList.SecondEdition
             UpgradeInfo = new UpgradeCardInfo(
                 "Saw Gerrera",
                 UpgradeType.Crew,
-                cost: 8,
+                cost: 9,
                 isLimited: true,
                 restriction: new FactionRestriction(Faction.Rebel),
                 abilityType: typeof(Abilities.FirstEdition.SawGerreraCrewAbility),

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/EzraBridger.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/EzraBridger.cs
@@ -15,7 +15,7 @@ namespace UpgradesList.SecondEdition
             UpgradeInfo = new UpgradeCardInfo(
                 "Ezra Bridger",
                 UpgradeType.Gunner,
-                cost: 18,
+                cost: 14,
                 isLimited: true,
                 addForce: 1,
                 abilityType: typeof(Abilities.SecondEdition.EzraBridgerGunnerAbility),


### PR DESCRIPTION
Source: https://images-cdn.fantasyflightgames.com/filer_public/34/d3/34d3e516-9636-4540-9e94-bb59115ee596/onlinepoints_rebelalliance_july_2019.pdf

NOTE: didn't update Maul crew point cost since that's already done in the Scum point update PR.