### PR TITLE
Fix trigger type for Clone Commander Cody

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/CloneCommanderCody.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/CloneCommanderCody.cs
@@ -49,14 +49,14 @@ namespace Abilities.SecondEdition
         {
             if (hitOrCritResults > 0)
             {
-                HostShip.OnCombatDeactivation += RegisterTrigger;
+                HostShip.OnAttackFinish += RegisterTrigger;
             }
         }
 
         private void RegisterTrigger(GenericShip ship)
         {
             HostShip.OnCombatDeactivation -= RegisterTrigger;
-            RegisterAbilityTrigger(TriggerTypes.OnCombatDeactivation, AssignStrainToDefender);
+            RegisterAbilityTrigger(TriggerTypes.OnAttackFinish, AssignStrainToDefender);
         }
 
         private void AssignStrainToDefender(object sender, System.EventArgs e)


### PR DESCRIPTION
OnAttackFinish should be used instead of OnCombatDeactivation to make sure Cody works correctly if the host ship can shoot the same target twice; if the first attack misses, Strain should be assigned as soon as that attack finishes (and decrease the target's Agility by 1 for the second attack) instead of waiting until the ship is deactivated for combat.

I originally used OnCombatDeactivation because I was afraid of possibly creating a race condition with the OnAttackFinish trigger that removes Strain from the defender (from StrainRule.cs).  But I just tested this and everything works as intended.