### PR TITLE
fix errors w/ Cat's ability

### DIFF
--- a/Assets/Scripts/Model/Combat/Bombs.cs
+++ b/Assets/Scripts/Model/Combat/Bombs.cs
@@ -105,7 +105,7 @@ namespace Bombs
             {
                 if (!ship.IsDestroyed)
                 {
-                    if (IsShipInDetonationRange(ship, bombObject, bombObject.ParentUpgrade.detonationRange))
+                    if (IsShipInRange(ship, bombObject, bombObject.ParentUpgrade.detonationRange))
                     {
                         result.Add(ship);
                     }
@@ -121,7 +121,7 @@ namespace Bombs
 
             foreach (var bombHolder in bombsList)
             {
-                if (IsShipInDetonationRange(ship, bombHolder.Key, bombHolder.Key.ParentUpgrade.detonationRange))
+                if (IsShipInRange(ship, bombHolder.Key, bombHolder.Key.ParentUpgrade.detonationRange))
                 {
                     result.Add(bombHolder.Value);
                 }
@@ -130,7 +130,7 @@ namespace Bombs
             return result;
         }
 
-        private static bool IsShipInDetonationRange(GenericShip ship, GenericDeviceGameObject bombObject, int range = 1)
+        public static bool IsShipInRange(GenericShip ship, GenericDeviceGameObject bombObject, int range = 1)
         {
             List<Vector3> bombPoints = GetBombPointsRelative();
 

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Mg100StarFortress/Cat.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Mg100StarFortress/Cat.cs
@@ -30,6 +30,7 @@ namespace Ship
 
 namespace Abilities.SecondEdition
 {
+    //While you perform a primary attack, if the defender is at range 0-1 of at least 1 friendly device, roll 1 additional die.
     public class CatAbility : GenericAbility
     {
         public override void ActivateAbility()
@@ -48,8 +49,8 @@ namespace Abilities.SecondEdition
             {
                 foreach (var bombHolder in BombsManager.GetBombsOnBoard())
                 {
-                    List<GenericShip> shipsNear = BombsManager.GetShipsInRange(bombHolder.Key);
-                    if (shipsNear.Contains(Combat.Defender) && bombHolder.Value.HostShip.Owner.PlayerNo == HostShip.Owner.PlayerNo)
+                    if (bombHolder.Value.HostShip.Owner.PlayerNo == HostShip.Owner.PlayerNo
+                        && BombsManager.IsShipInRange(Combat.Defender, bombHolder.Key, 1))
                     {
                         Messages.ShowInfo(HostShip.PilotInfo.PilotName + " gains +1 attack die");
                         count++;

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Mg100StarFortress/FinchDallow.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Mg100StarFortress/FinchDallow.cs
@@ -124,6 +124,7 @@ namespace SubPhases
         {
             GenericDeviceGameObject prefab = Resources.Load<GenericDeviceGameObject>(BombsManager.CurrentBomb.bombPrefabPath);
             BombGO = MonoBehaviour.Instantiate(prefab, bombPosition, bombRotation, Board.GetBoard());
+            BombGO.Initialize(BombsManager.CurrentBomb);
         }
 
         public void ShowDescription()


### PR DESCRIPTION
Fixes https://github.com/Sandrem/FlyCasual/issues/2019 (by adding missing initialization for bombs dropped with Finch's ability)

Fixes https://github.com/Sandrem/FlyCasual/issues/2024 (by explicitly checking for range 1 for all friendly devices as per Cat's ability, instead of relying on each device's detonation range, which is 0 for proximity mines)