### PR TITLE
Fix failed Fine-Tuned Controls barrel rolls causing Perform Action step to be skipped

### DIFF
--- a/Assets/Scripts/Model/Actions/ActionsList/BarrelRollAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/BarrelRollAction.cs
@@ -34,7 +34,7 @@ namespace ActionsList
         public override void RevertActionOnFail(bool hasSecondChance = false)
         {
             Phases.FinishSubPhase(typeof(BarrelRollPlanningSubPhase));
-            Phases.CurrentSubPhase.CallBack();
+            Phases.CurrentSubPhase.Resume();
         }
 
     }


### PR DESCRIPTION
While investigating #2035, I found that when using Fine-Tuned Controls, failed boosts do not cause the normal action to be skipped, only failed barrel rolls.  Comparing `BoostAction.cs` and `BarrelRollAction.cs`, I noticed that `BarrelRollAction.RevertActionOnFail` calls `Phases.CurrentSubPhase.Callback` instead of `Phases.CurrentSubPhase.Resume` (as done by `BoostAction.RevertActionOnFail`).  After switching to `Phases.CurrentSubPhase.Resume`, the issue was fixed.

Fixes #2035