### PR TITLE
Fix timing of Darth Sidious' ability

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/ChancellorPalpatine.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/ChancellorPalpatine.cs
@@ -140,16 +140,21 @@ namespace Abilities.SecondEdition
         private void CoordinateShipSelected(GenericShip ship)
         {
             TargetShip = ship;
-            ship.OnActionIsPerformed += RegisterAbility;            
+            HostShip.OnActionIsPerformed += RegisterAbility;
         }
 
         private void RegisterAbility(GenericAction action)
         {
-            TargetShip.OnActionIsPerformed -= RegisterAbility;
-            RegisterAbilityTrigger(TriggerTypes.OnActionIsPerformed, ShowDecision);
+            HostShip.OnActionIsPerformed -= RegisterAbility;
+            RegisterAbilityTrigger(TriggerTypes.OnActionIsPerformed, AssignStress);
         }
 
-        private void ShowDecision(object sender, EventArgs e)
+        private void AssignStress(object sender, EventArgs e)
+        {
+            TargetShip.Tokens.AssignToken(typeof(Tokens.StressToken), ShowDecision);
+        }
+
+        private void ShowDecision()
         {
             var phase = Phases.StartTemporarySubPhaseNew<DarthSidiousDecisionSubPhase>("Darth Sidious", Triggers.FinishTrigger);
             phase.TargetShip = TargetShip;


### PR DESCRIPTION
Update Darth Sidious ability to be more reflective of its text via the following changes:

- trigger ability after host ship's purple coordinate action is performed, instead of when target ship performs an action
- assign stress to target ship

Fixes #2048
Fixes #2052