### PR TITLE
Do not allow Countess Ryad's ability when ionized

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIEDDefender/CountessRyad.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIEDDefender/CountessRyad.cs
@@ -45,7 +45,9 @@ namespace Abilities.SecondEdition
         protected override void RegisterAskChangeManeuver(GenericShip ship)
         {
             //I have assumed that you can not use this ability if you execute a red maneuver
-            if (HostShip.AssignedManeuver.ColorComplexity != MovementComplexity.Complex && HostShip.AssignedManeuver.Bearing == ManeuverBearing.Straight)
+            if (HostShip.AssignedManeuver.ColorComplexity != MovementComplexity.Complex
+                && HostShip.AssignedManeuver.Bearing == ManeuverBearing.Straight
+                && !HostShip.Tokens.HasToken(typeof(Tokens.IonToken)))
             {
                 RegisterAbilityTrigger(TriggerTypes.BeforeMovementIsExecuted, AskChangeManeuver);
             }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIEDDefender/CountessRyad.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIEDDefender/CountessRyad.cs
@@ -47,7 +47,7 @@ namespace Abilities.SecondEdition
             //I have assumed that you can not use this ability if you execute a red maneuver
             if (HostShip.AssignedManeuver.ColorComplexity != MovementComplexity.Complex
                 && HostShip.AssignedManeuver.Bearing == ManeuverBearing.Straight
-                && !HostShip.Tokens.HasToken(typeof(Tokens.IonToken)))
+                && !HostShip.AssignedManeuver.IsIonManeuver)
             {
                 RegisterAbilityTrigger(TriggerTypes.BeforeMovementIsExecuted, AskChangeManeuver);
             }


### PR DESCRIPTION
Based on the rules for Ionized (https://xwing-miniatures-second-edition.fandom.com/wiki/Ionized), Countess Ryad's ability shouldn't be able to modify the Ion Maneuver since it doesn't explicitly mention being able to affect Ion maneuvers.

Fixes #1142