### PR TITLE
Fix Paige Tico ability

### DIFF
--- a/Assets/Scripts/Model/Combat/Bombs.cs
+++ b/Assets/Scripts/Model/Combat/Bombs.cs
@@ -214,9 +214,9 @@ namespace Bombs
             CheckBombDropAvailability(ship, TriggerTypes.OnMovementActivationStart);
         }
 
-        public static void CheckBombDropAvailability(GenericShip ship, TriggerTypes triggerType, UpgradeSubType subType = UpgradeSubType.None, bool onlyDrop = false)
+        public static void CheckBombDropAvailability(GenericShip ship, TriggerTypes triggerType, UpgradeSubType subType = UpgradeSubType.None, bool onlyDrop = false, bool isRealDrop = true)
         {
-            if (!ship.IsBombAlreadyDropped && HasBombsToDrop(ship, subType))
+            if ((!isRealDrop || !ship.IsBombAlreadyDropped) && HasBombsToDrop(ship, subType))
             {
                 Triggers.RegisterTrigger(new Trigger()
                 {

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/PaigeTico.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/PaigeTico.cs
@@ -74,14 +74,12 @@ namespace Abilities.SecondEdition
         {
             DecisionSubPhase.ConfirmDecisionNoCallback();
 
-            //TODO: Must not be an action
             HostShip.AskPerformFreeAction(
-                new RotateArcAction(),
+                new RotateArcAction() { IsRealAction = false },
                 Triggers.FinishTrigger,
                 HostUpgrade.UpgradeInfo.Name,
                 "After you perform a primary attack, you may rotate your Turret Arc",
-                HostUpgrade,
-                isForced: true
+                HostUpgrade
             );
         }
 

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/PaigeTico.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/PaigeTico.cs
@@ -121,7 +121,8 @@ namespace Abilities.SecondEdition
                 HostShip,
                 TriggerTypes.OnAbilityDirect,
                 subType: UpgradeSubType.Bomb,
-                onlyDrop: true
+                onlyDrop: true,
+                isRealDrop: false
             );
 
             Triggers.ResolveTriggers(TriggerTypes.OnAbilityDirect, Triggers.FinishTrigger);

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/PaigeTico.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Gunner/PaigeTico.cs
@@ -79,7 +79,8 @@ namespace Abilities.SecondEdition
                 Triggers.FinishTrigger,
                 HostUpgrade.UpgradeInfo.Name,
                 "After you perform a primary attack, you may rotate your Turret Arc",
-                HostUpgrade
+                HostUpgrade,
+                isForced: true
             );
         }
 


### PR DESCRIPTION
- allow rotate even if turret has already been rotated this turn
- allow bomb drop even if bomb has already been dropped this turn

Fixes #2068