### PR TITLE
SE Talonbane ability is not limited to primaries

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/KihraxzFighter/TalonbaneCobra.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/KihraxzFighter/TalonbaneCobra.cs
@@ -1,6 +1,4 @@
 ﻿using Ship;
-using System.Collections;
-using System.Collections.Generic;
 using Upgrade;
 
 namespace Ship
@@ -16,7 +14,7 @@ namespace Ship
                     5,
                     50,
                     isLimited: true,
-                    abilityType: typeof(Abilities.FirstEdition.TalonbaneCobraAbility),
+                    abilityType: typeof(Abilities.SecondEdition.TalonbaneCobraAbility),
                     extraUpgradeIcon: UpgradeType.Talent,
                     seImageNumber: 191
                 );
@@ -25,3 +23,34 @@ namespace Ship
     }
 }
 
+namespace Abilities.SecondEdition
+{
+    public class TalonbaneCobraAbility : GenericAbility
+    {
+        public override void ActivateAbility()
+        {
+            HostShip.AfterGotNumberOfAttackDice += TalonbaneCobraDiceCheck;
+            HostShip.AfterGotNumberOfDefenceDice += TalonbaneCobraDiceCheck;
+        }
+
+        public override void DeactivateAbility()
+        {
+            HostShip.AfterGotNumberOfAttackDice -= TalonbaneCobraDiceCheck;
+            HostShip.AfterGotNumberOfDefenceDice -= TalonbaneCobraDiceCheck;
+        }
+
+        private void TalonbaneCobraDiceCheck(ref int diceCount)
+        {
+            if (Combat.AttackStep == CombatStep.Attack && Combat.ShotInfo.Range == 1)
+            {
+                Messages.ShowInfo("Talonbane Cobra is attacking at range 1, gaining +1 attack die");
+                diceCount++;
+            }
+            if (Combat.AttackStep == CombatStep.Defence && Combat.ShotInfo.Range == 3)
+            {
+                Messages.ShowInfo("Talonbane Cobra is defending at range 3, gaining +1 defense die");
+                diceCount++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Unlike FE Talonbane, SE Talonbane ability is not limited to primary weapons.

Source: https://xwing-miniatures-second-edition.fandom.com/wiki/Talonbane_Cobra