### PR TITLE
SE Jam token decisions should belong to assigner instead of target

### DIFF
--- a/Assets/Scripts/Model/Actions/ActionsList/JamAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/JamAction.cs
@@ -128,7 +128,7 @@ namespace SubPhases
                     Name = "Jam",
                     TriggerOwner = Selection.ThisShip.Owner.PlayerNo,
                     TriggerType = TriggerTypes.OnTokenIsAssigned,
-                    EventHandler = (s,e)=>AssignJamToken(targetShip)
+                    EventHandler = (s,e)=>AssignJamToken(targetShip, jammingShip)
                 }
             );
 
@@ -141,9 +141,9 @@ namespace SubPhases
             });
         }
 
-        private void AssignJamToken(GenericShip targetShip)
+        private void AssignJamToken(GenericShip targetShip, GenericShip jammingShip)
         {
-            targetShip.Tokens.AssignToken(typeof(JamToken), Triggers.FinishTrigger);
+            targetShip.Tokens.AssignToken(new JamToken(targetShip, jammingShip.Owner), Triggers.FinishTrigger);
         }
 
         public override void RevertSubPhase()

--- a/Assets/Scripts/Model/Content/FirstEdition/Upgrades/Cannon/JammingBeam.cs
+++ b/Assets/Scripts/Model/Content/FirstEdition/Upgrades/Cannon/JammingBeam.cs
@@ -51,7 +51,7 @@ namespace Abilities.FirstEdition
             Combat.DiceRollAttack.CancelAllResults();
             Combat.DiceRollAttack.RemoveAllFailures();
 
-            Combat.Defender.Tokens.AssignToken(typeof(JamToken), Triggers.FinishTrigger);
+            Combat.Defender.Tokens.AssignToken(new JamToken(Combat.Defender, HostShip.Owner), Triggers.FinishTrigger);
         }
     }
 }

--- a/Assets/Scripts/Model/Content/FirstEdition/Upgrades/Crew/ISBSlicer.cs
+++ b/Assets/Scripts/Model/Content/FirstEdition/Upgrades/Crew/ISBSlicer.cs
@@ -74,7 +74,7 @@ namespace Abilities.FirstEdition
 
         private void AssignExtraJamToken()
         {
-            TargetShip.Tokens.AssignToken(typeof(JamToken), SelectShipSubPhase.FinishSelection);
+            TargetShip.Tokens.AssignToken(new JamToken(TargetShip, HostShip.Owner), SelectShipSubPhase.FinishSelection);
         }
 
         private bool IsShipWithoutJamAtRangeOneOfTarget(GenericShip ship)

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/ModifiedTIELnFighter/CaptainSeevor.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/ModifiedTIELnFighter/CaptainSeevor.cs
@@ -83,7 +83,7 @@ namespace Abilities.SecondEdition
             var jammingShip = HostShip;
 
             targetShip.Tokens.AssignToken(
-                new Tokens.JamToken(targetShip),
+                new Tokens.JamToken(targetShip, HostShip.Owner),
                 DecisionSubPhase.ConfirmDecision
             );
         }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/VCX100LightFreighter/Chopper.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/VCX100LightFreighter/Chopper.cs
@@ -38,7 +38,7 @@ namespace Abilities.SecondEdition
                 GenericShip shipToAssignStress = shipsToAssignStress[0];
                 shipsToAssignStress.Remove(shipToAssignStress);
                 Messages.ShowErrorToHuman(shipToAssignStress.PilotInfo.PilotName + " is at range 0 of \"Chopper\" and gains a jam token");
-                shipToAssignStress.Tokens.AssignTokens(() => new JamToken(shipToAssignStress), 2, AssignStressTokenRecursive);
+                shipToAssignStress.Tokens.AssignTokens(() => new JamToken(shipToAssignStress, HostShip.Owner), 2, AssignStressTokenRecursive);
             }
             else
             {

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Cannon/JammingBeam.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Cannon/JammingBeam.cs
@@ -37,7 +37,7 @@ namespace Abilities.SecondEdition
             Combat.DiceRollAttack.RemoveAllFailures();
 
             Combat.Defender.Tokens.AssignTokens(
-                () => new JamToken(Combat.Defender),
+                () => new JamToken(Combat.Defender, HostShip.Owner),
                 jammingBeamTokens,
                 Triggers.FinishTrigger
             );

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/FreelanceSlicer.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/FreelanceSlicer.cs
@@ -70,7 +70,7 @@ namespace Abilities.SecondEdition
             Messages.ShowInfo(HostUpgrade.UpgradeInfo.Name + ": " + Combat.Attacker.PilotInfo.PilotName + " gains 1 Jam Token");
 
             Combat.Attacker.Tokens.AssignToken(
-                typeof(JamToken),
+                new JamToken(Combat.Attacker, HostShip.Owner),
                 PerformCustomDiceCheck
             );
         }
@@ -92,7 +92,7 @@ namespace Abilities.SecondEdition
             {
                 Messages.ShowInfo(HostUpgrade.UpgradeInfo.Name + " Gain 1 Jam Token");
                 HostShip.Tokens.AssignToken(
-                    typeof(JamToken),
+                    new JamToken(HostShip, HostShip.Owner),
                     AbilityDiceCheck.ConfirmCheck
                 );
             }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/SabineWren.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/SabineWren.cs
@@ -32,7 +32,7 @@ namespace Abilities.SecondEdition
         Dictionary<GenericToken, string> ReadyTokens = new Dictionary<GenericToken, string>()
         {
             { new IonToken(null), "I" },
-            { new JamToken(null), "J" },
+            { new JamToken(null, null), "J" },
             { new StressToken(null), "S" },
             { new TractorBeamToken(null, null), "TB" }
         };
@@ -135,6 +135,16 @@ namespace Abilities.SecondEdition
             if (token == null)
             {
                 Triggers.FinishTrigger();
+            }
+            else if (token is JamToken)
+            {
+                ReadyTokens.Remove(token);
+                UpdateName();
+
+                BombEffectTargetShip.Tokens.AssignToken(
+                    new JamToken(BombEffectTargetShip, HostShip.Owner),
+                    Triggers.FinishTrigger
+                );
             }
             else if (token is TractorBeamToken)
             {

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/SeventhSister.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/SeventhSister.cs
@@ -98,7 +98,7 @@ namespace Abilities.SecondEdition
 
                 DecisionViewType = DecisionViewTypes.TextButtons;
 
-                AddDecision("Jam", delegate { TokenSelected(new Tokens.JamToken(TargetShip)); });
+                AddDecision("Jam", delegate { TokenSelected(new Tokens.JamToken(TargetShip, HostShip.Owner)); });
                 AddDecision("Tractor", delegate { TokenSelected(new Tokens.TractorBeamToken(TargetShip, HostShip.Owner)); });
 
                 DefaultDecisionName = GetDecisions().First().Name;

--- a/Assets/Scripts/Model/Tokens/JamToken.cs
+++ b/Assets/Scripts/Model/Tokens/JamToken.cs
@@ -1,15 +1,13 @@
 ﻿using Editions;
 using Ship;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
 
 namespace Tokens
 {
-
     public class JamToken : GenericToken
     {
-        public JamToken(GenericShip host) : base(host)
+        public Players.GenericPlayer Assigner;
+
+        public JamToken(GenericShip host, Players.GenericPlayer assigner) : base(host)
         {
             Name = "Jam Token";
             ImageName = (Edition.Current is SecondEdition) ? "Jam Token SE" : "Jam Token FE";
@@ -17,6 +15,7 @@ namespace Tokens
             TokenColor = TokenColors.Orange;
             PriorityUI = 40;
             Tooltip = "https://raw.githubusercontent.com/guidokessels/xwing-data/master/images/reference-cards/ReloadActionAndJamTokens.png";
+            Assigner = assigner;
         }
     }
 


### PR DESCRIPTION
NOTE: I didn't test every updated source of Jam tokens, but did test the following and verified that they gave the Jam decisions to the right player:

- tested performing Jam action (from the Resistance Transport) as the player in a hotseat game
- tested letting AI Seventh Sister crew jam my ship in an AI game

Fixes #2085