### PR TITLE
Fix Dauntless title's interaction with damage card actions

### DIFF
--- a/Assets/Scripts/Model/Actions/ActionsList/CancelCritAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/CancelCritAction.cs
@@ -7,14 +7,14 @@ namespace ActionsList
 
     public class CancelCritAction : GenericAction
     {
-        private GenericDamageCard CritCard;
+        public GenericDamageCard CritCard;
 
         public CancelCritAction()
         {
             IsCritCancelAction = true;
         }
 
-        public void Initilize(GenericDamageCard critCard)
+        public void Initialize(GenericDamageCard critCard)
         {
             CritCard = critCard;
 

--- a/Assets/Scripts/Model/Content/Core/DamageDeck/GenericDamageCard.cs
+++ b/Assets/Scripts/Model/Content/Core/DamageDeck/GenericDamageCard.cs
@@ -78,7 +78,7 @@ public class GenericDamageCard
     protected void AddCancelCritAction()
     {
         ActionsList.CancelCritAction cancelCritAction = new ActionsList.CancelCritAction();
-        cancelCritAction.Initilize(this);
+        cancelCritAction.Initialize(this);
         Host.AddAvailableAction(cancelCritAction);
     }
 

--- a/Assets/Scripts/Model/Content/Core/Ship/GenericShipActions.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/GenericShipActions.cs
@@ -127,6 +127,15 @@ namespace Ship
             return GetAvailableActions().Where(a => !a.IsRed).ToList();
         }
 
+        private GenericAction GetActionAsRed(GenericAction action)
+        {
+            //Make a deep clone to avoid changing the original action to red
+            GenericAction instance = (GenericAction)Activator.CreateInstance(action.GetType());
+            if (instance.IsCritCancelAction) ((CancelCritAction)instance).Initialize(((CancelCritAction)action).CritCard);
+            instance.Color = ActionColor.Red;
+            return instance;
+        }
+
         public List<GenericAction> GetAvailableActionsAsRed()
         {
             List<GenericAction> redActions = new List<GenericAction>();
@@ -135,8 +144,7 @@ namespace Ship
 
             foreach(GenericAction action in AvailableActionsList)
             {
-                action.Color = ActionColor.Red;
-                redActions.Add(action);
+                redActions.Add(GetActionAsRed(action));
             }
 
             return redActions;
@@ -150,8 +158,7 @@ namespace Ship
 
             foreach (GenericAction action in AvailableActionsList.Where(n => !n.IsRed))
             {
-                action.Color = ActionColor.Red;
-                redActions.Add(action);
+                redActions.Add(GetActionAsRed(action));
             }
 
             return redActions;

--- a/Assets/Scripts/Model/Content/Core/Ship/GenericShipActions.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/GenericShipActions.cs
@@ -135,9 +135,8 @@ namespace Ship
 
             foreach(GenericAction action in AvailableActionsList)
             {
-                GenericAction instance = (GenericAction)Activator.CreateInstance(action.GetType());
-                instance.Color = ActionColor.Red;
-                redActions.Add(instance);
+                action.Color = ActionColor.Red;
+                redActions.Add(action);
             }
 
             return redActions;
@@ -151,9 +150,8 @@ namespace Ship
 
             foreach (GenericAction action in AvailableActionsList.Where(n => !n.IsRed))
             {
-                GenericAction instance = (GenericAction)Activator.CreateInstance(action.GetType());
-                instance.Color = ActionColor.Red;
-                redActions.Add(instance);
+                action.Color = ActionColor.Red;
+                redActions.Add(action);
             }
 
             return redActions;


### PR DESCRIPTION
As per #2087, code that called `GetAvailableActionsWhiteOnlyAsRed` (and `GetAvailableActionsWhiteOnly`), such as the Dauntless title, were not showing damage card actions as options.

The root cause seems to be the use of `Activator.CreateInstance` to create copies of actions, which doesn't fully work for `CancelCritAction`s because they perform additional initialization in the `CancelCritAction.Initilize` method.

This PR removes the calls to `Activator.CreateInstance`, which appears to work in my testing.  But if this causes problems elsewhere and I need to use a different approach, just let me know!

Fixes #2087