### PR TITLE
Minor clarifications for multi-target Coordinate messages

### DIFF
--- a/Assets/Scripts/Model/Actions/ActionsList/CoordinateAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/CoordinateAction.cs
@@ -71,7 +71,7 @@ namespace ActionsList
                 subphase.CoordinateActionData = CoordinateActionData;
 
                 subphase.DescriptionShort = "Coordinate Action";
-                subphase.DescriptionLong = "Select another ships.\nThey perform free action.";
+                subphase.DescriptionLong = "Select one or more other ships.\nThey will each perform an action.";
 
                 subphase.Start();
             }
@@ -221,7 +221,7 @@ namespace SubPhases
                 Selection.ThisShip.Owner.PlayerNo,
                 false,
                 "Coordinate Action",
-                "Select another ship.\nIt performs free action."
+                "Select another ship.\nIt will perform an action."
             );
         }
 

--- a/Assets/Scripts/Model/Phases/SubPhases/Temporary/MultiSelectionSubphase.cs
+++ b/Assets/Scripts/Model/Phases/SubPhases/Temporary/MultiSelectionSubphase.cs
@@ -83,10 +83,6 @@ namespace SubPhases
                 {
                     Selection.ToggleMultiSelection(ship);
                 }
-                else
-                {
-                    Messages.ShowError("Only " + MaxToSelect + " ships can be selected");
-                }
             }
 
             return false;


### PR DESCRIPTION
Also removes a redundant error message in `MultiSelectionSubphase.ThisShipCanBeSelected`, which is already checked/shown in `MultiSelectionSubphase.CanBeToggled`, which is already called from `ThisShipCanBeSelected`.