### PR TITLE
Fix ship state Force/Charge setters

### DIFF
--- a/Assets/Scripts/Model/Content/Core/Ship/ShipStateInfo/ShipStateInfo.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/ShipStateInfo/ShipStateInfo.cs
@@ -148,14 +148,30 @@ namespace Ship
             {
                 for (int i = 0; i < currentTokens - value; i++)
                 {
-                    HostShip.Tokens.RemoveToken(tokenType, delegate { });
+                    if (Phases.CurrentPhase is MainPhases.SetupPhase)
+                    {
+                        //skip triggers during Setup phase
+                        HostShip.Tokens.RemoveCondition(tokenType);
+                    }
+                    else
+                    {
+                        HostShip.Tokens.RemoveToken(tokenType, delegate { });
+                    }
                 }
             }
             else if (value > currentTokens)
             {
                 for (int i = 0; i < value - currentTokens; i++)
                 {
-                    HostShip.Tokens.AssignToken(tokenType, delegate { });
+                    if (Phases.CurrentPhase is MainPhases.SetupPhase)
+                    {
+                        //skip triggers during Setup phase
+                        HostShip.Tokens.AssignCondition(tokenType);
+                    }
+                    else
+                    {
+                        HostShip.Tokens.AssignToken(tokenType, delegate { });
+                    }
                 }
             }
         }

--- a/Assets/Scripts/Model/Content/Core/Ship/ShipStateInfo/ShipStateInfo.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/ShipStateInfo/ShipStateInfo.cs
@@ -137,10 +137,25 @@ namespace Ship
 
             set
             {
-                HostShip.Tokens.RemoveAllTokensByType(typeof(ForceToken), delegate { });
-                for (int i = 0; i < value; i++)
+                UpdateTokens(value, typeof(ForceToken));
+            }
+        }
+
+        private void UpdateTokens(int value, Type tokenType)
+        {
+            int currentTokens = HostShip.Tokens.CountTokensByType(tokenType);
+            if (currentTokens > value)
+            {
+                for (int i = 0; i < currentTokens - value; i++)
                 {
-                    HostShip.Tokens.AssignCondition(typeof(ForceToken));
+                    HostShip.Tokens.RemoveToken(tokenType, delegate { });
+                }
+            }
+            else if (value > currentTokens)
+            {
+                for (int i = 0; i < value - currentTokens; i++)
+                {
+                    HostShip.Tokens.AssignToken(tokenType, delegate { });
                 }
             }
         }
@@ -155,17 +170,8 @@ namespace Ship
             get { return charges; }
             set
             {
-                int currentTokens = HostShip.Tokens.CountTokensByType(typeof(ChargeToken));
-                for (int i = 0; i < currentTokens; i++)
-                {
-                    HostShip.Tokens.RemoveCondition(typeof(ChargeToken));
-                }
-
+                UpdateTokens(value, typeof(ChargeToken));
                 charges = value;
-                for (int i = 0; i < value; i++)
-                {
-                    HostShip.Tokens.AssignCondition(typeof(ChargeToken));
-                }
             }
         }
 


### PR DESCRIPTION
While investigating #2101, I found that ShipStateInfo's Force & Charge setters were removing all tokens of the type and then calling `AssignCondition` to assign the new amount of tokens.

The Force setter was calling `RemoveAllTokensByType`, which is why the Force removal animation was being mistakenly shown at the end of the turn, when the Force setter is called to recharge the Force.

This PR creates a new `UpdateTokens` helper method that calculates the difference between the current and new token amounts then calls AssignToken/RemoveToken the appropriate number of times, which has the following benefits:

- fixes animation for end-of-turn Force recharge
- animation is now also shown when Charge tokens are used/recharged

NOTE: during Setup phase, `UpdateTokens` will use AssignCondition/RemoveCondition instead to avoid firing triggers, to avoid unwanted token animations at the start of the game.

Fixes #2101 