### PR TITLE
Fix Sunny Bounder ability

### DIFF
--- a/Assets/Scripts/Model/Content/FirstEdition/Pilots/M3AInterceptor/SunnyBounder.cs
+++ b/Assets/Scripts/Model/Content/FirstEdition/Pilots/M3AInterceptor/SunnyBounder.cs
@@ -32,30 +32,22 @@ namespace Abilities.FirstEdition
     {
         public override void ActivateAbility()
         {
-            HostShip.OnImmediatelyAfterRolling += AddAbility;
-            HostShip.OnImmediatelyAfterReRolling += AddAbility;
+            HostShip.OnGenerateDiceModifications += AddAbility;
             Phases.Events.OnRoundEnd += ClearIsAbilityUsedFlag;
         }
 
         public override void DeactivateAbility()
         {
-            HostShip.OnImmediatelyAfterRolling -= AddAbility;
-            HostShip.OnImmediatelyAfterReRolling -= AddAbility;
+            HostShip.OnGenerateDiceModifications -= AddAbility;
             Phases.Events.OnRoundEnd -= ClearIsAbilityUsedFlag;
         }
 
-        protected virtual void AddAbility(DiceRoll diceroll)
+        protected virtual void AddAbility(GenericShip ship)
         {
-            if (!IsAbilityUsed && diceroll.DiceList.All(die => die.Side == diceroll.DiceList.First().Side))
+            if (!IsAbilityUsed && Combat.CurrentDiceRoll.DiceList.All(die => die.Side == Combat.CurrentDiceRoll.DiceList.First().Side))
             {
-                HostShip.OnGenerateDiceModifications += AddAvailableActionEffect;
+                HostShip.AddAvailableDiceModification(new ActionsList.FirstEdition.SunnyBounderAbilityAction(() => { IsAbilityUsed = true; }));
             }
-        }
-
-        protected void AddAvailableActionEffect(GenericShip ship)
-        {
-            ship.AddAvailableDiceModification(new ActionsList.FirstEdition.SunnyBounderAbilityAction(() => { IsAbilityUsed = true; }));
-            HostShip.OnGenerateDiceModifications -= AddAvailableActionEffect;
         }
     }
 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/M3AInterceptor/SunnyBounder.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/M3AInterceptor/SunnyBounder.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using Ship;
+using System.Linq;
 
 namespace Ship
 {
@@ -26,11 +27,11 @@ namespace Abilities.SecondEdition
     public class SunnyBounderAbility : Abilities.FirstEdition.SunnyBounderAbility
     {
         // No more "once per round".
-        protected override void AddAbility(DiceRoll diceroll)
+        protected override void AddAbility(GenericShip ship)
         {
-            if (diceroll.DiceList.All(die => die.Side == diceroll.DiceList.First().Side))
+            if (Combat.CurrentDiceRoll.DiceList.All(die => die.Side == Combat.CurrentDiceRoll.DiceList.First().Side))
             {
-                HostShip.OnGenerateDiceModifications += AddAvailableActionEffect;
+                HostShip.AddAvailableDiceModification(new ActionsList.FirstEdition.SunnyBounderAbilityAction(() => { IsAbilityUsed = true; }));
             }
         }
     }


### PR DESCRIPTION
Verified that if the conditions are met, Sunny Bounder's ability now shows up correctly as an option even after reroll (for example, after using Target Lock).

Fixes #1667