### PR TITLE
WIP feat(WIP ships): Add padme pilot cs and meta

### DIFF
--- a/Assets/Scripts/Model/Board/Dice/DiceRoll.cs
+++ b/Assets/Scripts/Model/Board/Dice/DiceRoll.cs
@@ -406,8 +406,11 @@ public partial class DiceRoll
         {
             if (die.Side == oldSide)
             {
-                die.SetSide(newSide);
-                die.SetModelSide(newSide);
+                
+                if (die.SetSide(newSide, false))
+                {
+                    die.SetModelSide(newSide);
+                }
                 changedDiceCount++;
                 if (cannotBeRerolled) die.IsRerolled = true;
                 if (cannotBeModified) die.CannotBeModified = true;

--- a/Assets/Scripts/Model/Board/Dice/DiceRoll.cs
+++ b/Assets/Scripts/Model/Board/Dice/DiceRoll.cs
@@ -402,19 +402,19 @@ public partial class DiceRoll
     {
         var changedDiceCount = 0;
         OrganizeDicePositions();
+
         foreach (Die die in DiceList)
         {
             if (die.Side == oldSide)
             {
-                
-                if (die.SetSide(newSide, false))
+                if (die.TrySetSide(newSide, isInitial: false))
                 {
                     die.SetModelSide(newSide);
+                    changedDiceCount++;
+                    if (cannotBeRerolled) die.IsRerolled = true;
+                    if (cannotBeModified) die.CannotBeModified = true;
+                    if (onlyOne) return changedDiceCount;
                 }
-                changedDiceCount++;
-                if (cannotBeRerolled) die.IsRerolled = true;
-                if (cannotBeModified) die.CannotBeModified = true;
-                if (onlyOne) return changedDiceCount;
             }
         }
 
@@ -597,7 +597,7 @@ public partial class DiceRoll
                 die.Model.GetComponentInChildren<Rigidbody>().isKinematic = true;
 
                 DieSide face = die.GetModelFace();
-                die.SetSide(face);
+                die.TrySetSide(face);
 
                 if (die.IsWaitingForNewResult)
                 {
@@ -631,7 +631,7 @@ public partial class DiceRoll
 
             if (die.Side != sides[i])
             {
-                die.SetSide(sides[i]);
+                die.TrySetSide(sides[i]);
                 die.SetModelSide(sides[i]);
 
                 wasFixed = true;

--- a/Assets/Scripts/Model/Board/Dice/Die.cs
+++ b/Assets/Scripts/Model/Board/Dice/Die.cs
@@ -70,9 +70,27 @@ public partial class Die
         Side = DieSide.Blank;
     }
 
-    public void SetSide(DieSide side)
-    {
-        Side = side;
+    public bool SetSide(DieSide side, bool isInitial = true)
+    {   
+        if (isInitial)
+        {
+            Side = side;
+            return true;
+        }
+
+        bool isAllowed = true;
+        // Combat.CurrentDiceRoll.
+        // Issues: we don't know what the DiceModificationType is when we get into this base level function.
+        // isInitial needs to be set only on the initial roll (or when specific cards want to override the functionality to treat the roll like an initial roll)
+        Selection.ActiveShip.TryDiceResultModification(
+            this, Abilities.GenericAbility.DiceModificationType.Change, side, ref isAllowed);
+        if (isAllowed) {
+            Side = side;
+            return true;
+        } else {
+            return false;
+        }
+        
     }
 
     public DieSide Side

--- a/Assets/Scripts/Model/Board/Dice/Die.cs
+++ b/Assets/Scripts/Model/Board/Dice/Die.cs
@@ -70,27 +70,35 @@ public partial class Die
         Side = DieSide.Blank;
     }
 
-    public bool SetSide(DieSide side, bool isInitial = true)
-    {   
+    public bool TrySetSide(DieSide newSide, bool isInitial = true)
+    {
+        // isInitial needs to be set only on the initial roll (or when specific cards want to override the functionality to treat the roll like an initial roll)
         if (isInitial)
         {
-            Side = side;
+            Side = newSide;
             return true;
         }
 
         bool isAllowed = true;
-        // Combat.CurrentDiceRoll.
+
         // Issues: we don't know what the DiceModificationType is when we get into this base level function.
-        // isInitial needs to be set only on the initial roll (or when specific cards want to override the functionality to treat the roll like an initial roll)
-        Selection.ActiveShip.TryDiceResultModification(
-            this, Abilities.GenericAbility.DiceModificationType.Change, side, ref isAllowed);
-        if (isAllowed) {
-            Side = side;
+        Selection.ActiveShip.TryDiceResultModification
+        (
+            this,
+            Abilities.GenericAbility.DiceModificationType.Change,
+            newSide,
+            ref isAllowed
+        );
+
+        if (isAllowed)
+        {
+            Side = newSide;
             return true;
-        } else {
+        }
+        else
+        {
             return false;
         }
-        
     }
 
     public DieSide Side

--- a/Assets/Scripts/Model/Content/Core/Ability/GenericAbility.cs
+++ b/Assets/Scripts/Model/Content/Core/Ability/GenericAbility.cs
@@ -404,7 +404,7 @@ namespace Abilities
 
         // DICE MODIFICATIONS
 
-        protected enum DiceModificationType
+        public enum DiceModificationType
         {
             Reroll,
             Change,

--- a/Assets/Scripts/Model/Content/Core/Ship/GenericShipCombat.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/GenericShipCombat.cs
@@ -460,8 +460,10 @@ namespace Ship
 
         public bool TryDiceResultModification(Die die, GenericAbility.DiceModificationType modType, DieSide newResult, ref bool isAllowed)
         {
-            // (Die die, string modType, DieSide newResult, bool isAllowed)
-            if (OnTryDiceResultModification != null) OnTryDiceResultModification(die, modType, newResult, ref isAllowed);
+            if (OnTryDiceResultModification != null)
+            {
+                OnTryDiceResultModification(die, modType, newResult, ref isAllowed);
+            }
             return isAllowed;
         }
 

--- a/Assets/Scripts/Model/Content/Core/Ship/GenericShipCombat.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/GenericShipCombat.cs
@@ -154,6 +154,7 @@ namespace Ship
 
         public event EventHandler AfterAttackDiceModification;
         public event EventHandlerModifyDice OnTryDiceResultModification;
+        public event EventHandlerTrySelectDie OnTrySelectDie;
 
         public event EventHandler OnBombWillBeDropped;
         public event EventHandler OnBombWasDropped;
@@ -464,6 +465,12 @@ namespace Ship
             {
                 OnTryDiceResultModification(die, modType, newResult, ref isAllowed);
             }
+            return isAllowed;
+        }
+
+        public bool TrySelectDie(Die die, ref bool isAllowed)
+        {
+            if (OnTrySelectDie != null) OnTrySelectDie(die, ref isAllowed);
             return isAllowed;
         }
 

--- a/Assets/Scripts/Model/Content/Core/Ship/GenericShipCombat.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/GenericShipCombat.cs
@@ -1,4 +1,5 @@
-﻿using ActionsList;
+﻿using Abilities;
+using ActionsList;
 using Arcs;
 using BoardTools;
 using Movement;
@@ -152,6 +153,7 @@ namespace Ship
         public event EventHandler OnAfterNeutralizeResults;
 
         public event EventHandler AfterAttackDiceModification;
+        public event EventHandlerModifyDice OnTryDiceResultModification;
 
         public event EventHandler OnBombWillBeDropped;
         public event EventHandler OnBombWasDropped;
@@ -454,6 +456,13 @@ namespace Ship
         public void CallAfterNumberOfDefenceDiceConfirmed(int numDefenceDice)
         {
             if (AfterNumberOfDefenceDiceConfirmed != null) AfterNumberOfDefenceDiceConfirmed(ref numDefenceDice);
+        }
+
+        public bool TryDiceResultModification(Die die, GenericAbility.DiceModificationType modType, DieSide newResult, ref bool isAllowed)
+        {
+            // (Die die, string modType, DieSide newResult, bool isAllowed)
+            if (OnTryDiceResultModification != null) OnTryDiceResultModification(die, modType, newResult, ref isAllowed);
+            return isAllowed;
         }
 
         // REGEN

--- a/Assets/Scripts/Model/Content/Core/Ship/GenericShipEvents.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/GenericShipEvents.cs
@@ -1,4 +1,5 @@
-﻿using Actions;
+﻿using Abilities;
+using Actions;
 using ActionsList;
 using Arcs;
 using BoardTools;
@@ -61,6 +62,7 @@ namespace Ship
         public delegate void EventHandlerActionShip(GenericAction action, GenericShip wrongTarget);
         public delegate void EventHandlerCoordinateData(ref CoordinateActionData coordinateActionData);
 
+        public delegate void EventHandlerModifyDice(Die die, GenericAbility.DiceModificationType modType, DieSide newResult, ref bool isAllowed);
         public event EventHandlerShip AfterStatsAreChanged;
         public event EventHandlerInt AfterGetMaxHull;
         public event EventHandlerForceAlignmentBool OnForceAlignmentEquipCheck;

--- a/Assets/Scripts/Model/Content/Core/Ship/GenericShipEvents.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/GenericShipEvents.cs
@@ -63,6 +63,7 @@ namespace Ship
         public delegate void EventHandlerCoordinateData(ref CoordinateActionData coordinateActionData);
 
         public delegate void EventHandlerModifyDice(Die die, GenericAbility.DiceModificationType modType, DieSide newResult, ref bool isAllowed);
+        public delegate void EventHandlerTrySelectDie(Die die, ref bool isAllowed);
         public event EventHandlerShip AfterStatsAreChanged;
         public event EventHandlerInt AfterGetMaxHull;
         public event EventHandlerForceAlignmentBool OnForceAlignmentEquipCheck;

--- a/Assets/Scripts/Model/Content/FirstEdition/Upgrades/Bomb/ClusterMines.cs
+++ b/Assets/Scripts/Model/Content/FirstEdition/Upgrades/Bomb/ClusterMines.cs
@@ -78,7 +78,7 @@ namespace SubPhases
             {
                 foreach (Die die in CurrentDiceRoll.DiceList)
                 {
-                    if (die.Side == DieSide.Crit) die.SetSide(DieSide.Success);
+                    if (die.Side == DieSide.Crit) die.TrySetSide(DieSide.Success);
                 }
 
                 SufferDamage();

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/NabooRoyalN1Starfighter/PadmeAmidala.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/NabooRoyalN1Starfighter/PadmeAmidala.cs
@@ -1,0 +1,75 @@
+﻿using Abilities.SecondEdition;
+using System.Collections;
+using System.Collections.Generic;
+using Upgrade;
+
+namespace Ship
+{
+  namespace SecondEdition.NabooRoyalN1Starfighter
+  {
+    public class PadmeAmidala : NabooRoyalN1Starfighter
+    {
+      public PadmeAmidala() : base()
+      {
+        PilotInfo = new PilotCardInfo(
+            "Padmé Amidala",
+            4,
+            45,
+            isLimited: true,
+            abilityText: "While an enemy ship in your [Front Arc] defends or performs an attack, that ship can modify only 1 [Focus] result (other results can still be modified).",
+            abilityType: typeof(PadmeAmidalaAbility),
+            extraUpgradeIcon: UpgradeType.Talent
+        );
+
+        ImageUrl = "https://images-cdn.fantasyflightgames.com/filer_public/80/40/8040bcab-ebc0-487e-8dff-bd69da7311dd/swz40_padme-amidala.png";
+      }
+    }
+  }
+}
+
+namespace Abilities.SecondEdition
+{
+  public class PadmeAmidalaAbility : GenericAbility
+  {
+    public override void ActivateAbility()
+    {
+      HostShip.AfterGotNumberOfPrimaryWeaponAttackDice += CheckAttackAbility;
+      HostShip.AfterGotNumberOfDefenceDice += CheckDefensebility;
+    }
+
+    public override void DeactivateAbility()
+    {
+      HostShip.AfterGotNumberOfPrimaryWeaponAttackDice -= CheckAttackAbility;
+      HostShip.AfterGotNumberOfDefenceDice -= CheckDefensebility;
+    }
+
+    private void CheckPadmeAbility()
+    {
+      // Rules.TargetIsLegalForShot.IsLegal(Selection.ThisShip, Selection.AnotherShip, ChosenWeapon, isSilent)
+      //   ShotInfo shotInfo = new ShotInfo(thisShip, anotherShip, checkedWeapon)
+      if (Combat.Defender.Owner != HostShip.Owner
+          && GetFiringRangeAndShow(HostShip, Combat.Defender))
+      {
+        Messages.ShowInfo("Padmé Amidala: Defender can only modify 1 focus result");
+        // apply defensive focus mod limitation
+      }
+      if (Combat.Attacker.Owner != HostShip.Owner
+          && GetFiringRangeAndShow(HostShip, Combat.Attacker))
+      {
+        Messages.ShowInfo("Padmé Amidala: Attacker can only modify 1 focus result");
+        // apply offensive focus mod limitation
+      }
+    }
+
+    // private void CheckDefensebility(ref int count)
+    // {
+    //     if (HostShip.RevealedManeuver == null || Combat.Attacker.RevealedManeuver == null) return;
+
+    //     if (HostShip.RevealedManeuver.Speed > Combat.Attacker.RevealedManeuver.Speed)
+    //     {
+    //         Messages.ShowInfo("Ric Olie: +1 defense die");
+    //         count++;
+    //     }
+    // }
+  }
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/NabooRoyalN1Starfighter/PadmeAmidala.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/NabooRoyalN1Starfighter/PadmeAmidala.cs
@@ -93,22 +93,38 @@ namespace Conditions
             Messages.ShowInfo("Padmé Amidala: " + Host.PilotInfo.PilotName + " can only modify 1 focus result for this attack.");
             FocusHasBeenModified = false;
             
-            Host.OnTryDiceResultModification += CheckIfCanModifyFocus;
+            Host.OnTryDiceResultModification += CheckIfCanChangeDie;
+            Host.OnTrySelectDie += CheckIfCanSelectDie;
 
             Host.OnAttackFinishAsDefender += RemovePadmeAmidalaCondition;
             Host.OnAttackFinishAsAttacker += RemovePadmeAmidalaCondition;
         }
 
-        public void CheckIfCanModifyFocus(
+        public void CheckIfCanChangeDie(
           Die die, Abilities.GenericAbility.DiceModificationType modType, DieSide newResult, ref bool isAllowed
         )
         // Add focus modification limitation code here.
         {
           // set FocusHasBeenModified in some check in here
-          if (FocusHasBeenModified == true)
+          if (FocusHasBeenModified == true && die.Side == DieSide.Focus)
           {
             isAllowed = false;
             Messages.ShowInfo("Padmé Amidala: Die modification is prevented");
+          }
+          else if (die.Side == DieSide.Focus)
+          {
+            FocusHasBeenModified = true;
+          }
+        }
+
+        public void CheckIfCanSelectDie(
+          Die die, ref bool isAllowed
+        )
+        {
+          if (FocusHasBeenModified == true && die.Side == DieSide.Focus)
+          {
+            isAllowed = false;
+            Messages.ShowErrorToHuman("Padmé Amidala: Unable to select focus results");
           }
           else if (die.Side == DieSide.Focus)
           {
@@ -125,7 +141,8 @@ namespace Conditions
             Messages.ShowInfo("Padmé Amidala: " + Host.PilotInfo.PilotName + "'s ability to modify focus results restored");
 
             // remove focus modification limitation code here.
-            Host.OnTryDiceResultModification -= CheckIfCanModifyFocus;
+            Host.OnTryDiceResultModification -= CheckIfCanChangeDie;
+            Host.OnTrySelectDie -= CheckIfCanSelectDie;
 
             Host.OnAttackFinishAsDefender -= RemovePadmeAmidalaCondition;
             Host.OnAttackFinishAsAttacker -= RemovePadmeAmidalaCondition;

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/NabooRoyalN1Starfighter/PadmeAmidala.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/NabooRoyalN1Starfighter/PadmeAmidala.cs
@@ -90,7 +90,7 @@ namespace Conditions
 
         public override void WhenAssigned()
         {
-            Messages.ShowInfo("Padme Amidala: " + Host.PilotInfo.PilotName + " can only modify 1 focus result for this attack.");
+            Messages.ShowInfo("Padmé Amidala: " + Host.PilotInfo.PilotName + " can only modify 1 focus result for this attack.");
             FocusHasBeenModified = false;
             
             Host.OnTryDiceResultModification += CheckIfCanModifyFocus;
@@ -108,6 +108,7 @@ namespace Conditions
           if (FocusHasBeenModified == true)
           {
             isAllowed = false;
+            Messages.ShowInfo("Padmé Amidala: Die modification is prevented");
           }
           else if (die.Side == DieSide.Focus)
           {
@@ -121,7 +122,7 @@ namespace Conditions
 
         public override void WhenRemoved()
         {
-            Messages.ShowInfo("Padme Amidala: " + Host.PilotInfo.PilotName + "'s ability to modify focus results restored");
+            Messages.ShowInfo("Padmé Amidala: " + Host.PilotInfo.PilotName + "'s ability to modify focus results restored");
 
             // remove focus modification limitation code here.
             Host.OnTryDiceResultModification -= CheckIfCanModifyFocus;

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/NabooRoyalN1Starfighter/PadmeAmidala.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/NabooRoyalN1Starfighter/PadmeAmidala.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: wrongwrong4b1e2873e355c364391e18861aa615eawrongwrong
+guid: fa2f749bdfbfb42a194be5a85d70367f
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/NabooRoyalN1Starfighter/PadmeAmidala.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/NabooRoyalN1Starfighter/PadmeAmidala.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: wrongwrong4b1e2873e355c364391e18861aa615eawrongwrong
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Add padme pilot cs and meta files
  - Convert Ric Olie into padme
    - Update Price
    - Update Initiative
    - Update ability text
    - Update ImageUrl to ffg cdn
  - Unsure of how to generate GUIDs coorectly since I'm not using the unity editor
- begin logic for pilot ability
  - CheckPadmeAbility function logic to determine whether or not padme's ability should trigger for a shot
    - There are 2 commented methods for check validity of padme arc. Is there a preferred method for checking?
  - Unsure of correct hook to use to affect dice modifications and limit focus modifications to 1
    - Seems like we'd need to change:
      - `TryModifyDice`
      - some function(s) in `DiceRerollManager` in order to prevent selecting more than 1 focus result in a reroll (where focus has not been modified) or any focus results (where focus has already been modified). 