### PR TITLE
Make Rattled and Suppressive Fire conditions limited

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Mg100StarFortress/BenTeene.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Mg100StarFortress/BenTeene.cs
@@ -56,7 +56,7 @@ namespace Abilities.SecondEdition
 
                 AssignedCondition = new RattledCondition(Combat.Defender, HostShip);
                 SufferedShip = Combat.Defender;
-                Combat.Defender.Tokens.AssignCondition(AssignedCondition);
+                SufferedShip.Tokens.AssignCondition(AssignedCondition);
             }
         }
 

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Mg100StarFortress/BenTeene.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Mg100StarFortress/BenTeene.cs
@@ -1,12 +1,9 @@
 ﻿using ActionsList;
 using Arcs;
-using BoardTools;
 using Bombs;
+using Conditions;
 using Ship;
-using System.Collections;
-using System.Collections.Generic;
 using Tokens;
-using UnityEngine;
 using Upgrade;
 
 namespace Ship
@@ -37,6 +34,9 @@ namespace Abilities.SecondEdition
 {
     public class BenTeeneAbility : GenericAbility
     {
+        private RattledCondition AssignedCondition;
+        private GenericShip SufferedShip;
+
         public override void ActivateAbility()
         {
             HostShip.OnAttackFinishAsAttacker += CheckAbility;
@@ -51,10 +51,24 @@ namespace Abilities.SecondEdition
         {
             if (Combat.ShotInfo.InArcByType(ArcType.SingleTurret))
             {
+                RemoveCondition();
                 Messages.ShowInfo("The \"Rattled\" condition has been assigned to " + Combat.Defender.PilotInfo.PilotName);
-                Combat.Defender.Tokens.AssignCondition(
-                    new Conditions.RattledCondition(Combat.Defender, HostShip)
-                );
+
+                AssignedCondition = new RattledCondition(Combat.Defender, HostShip);
+                SufferedShip = Combat.Defender;
+                Combat.Defender.Tokens.AssignCondition(AssignedCondition);
+            }
+        }
+
+        private void RemoveCondition()
+        {
+            if (SufferedShip != null)
+            {
+                Messages.ShowInfo("The \"Rattled\" condition has been removed from " + SufferedShip.PilotInfo.PilotName);
+
+                SufferedShip.Tokens.RemoveCondition(AssignedCondition);
+                SufferedShip = null;
+                AssignedCondition = null;
             }
         }
     }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIELnFighter/CaptainRex.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIELnFighter/CaptainRex.cs
@@ -55,6 +55,7 @@ namespace Abilities.SecondEdition
 
         private void AssignConditionToDefender(GenericShip ship)
         {
+            RemoveCondition();
             Messages.ShowInfo("Suppressive Fire has been assigned by Captain Rex");
 
             AssignedCondition = new CaptainRexCondition(Combat.Defender) { Source = HostShip };

--- a/Assets/Scripts/Model/Phases/SubPhases/GenericSubPhase.cs
+++ b/Assets/Scripts/Model/Phases/SubPhases/GenericSubPhase.cs
@@ -94,7 +94,7 @@ namespace SubPhases
         public virtual bool AnotherShipCanBeSelected(GenericShip targetShip, int mouseKeyIsPressed)
         {
             bool result = false;
-            Messages.ShowErrorToHuman(targetShip.PilotName + "is owned by another player!");
+            Messages.ShowErrorToHuman(targetShip.PilotInfo.PilotName + " is owned by another player!");
             return result;
         }
 


### PR DESCRIPTION
Also adds small fix to ensure pilot name is shown by "X is owned by another player" message.

Fixes #1653