### PR TITLE
trigger CheckSkipPerformAction when movement finishes

### DIFF
--- a/Assets/Scripts/Model/Rules/RulesList/CollisionRules.cs
+++ b/Assets/Scripts/Model/Rules/RulesList/CollisionRules.cs
@@ -20,10 +20,10 @@ namespace RulesList
                 GenericShip.OnTryPerformAttackGlobal += CanPerformAttack;
                 RuleIsInitialized = true;
             }
-            Phases.Events.BeforeActionSubPhaseStart += CheckSkipPerformAction;
+            GenericShip.OnMovementFinishGlobal += CheckSkipPerformAction;
         }
 
-        public void CheckSkipPerformAction()
+        public void CheckSkipPerformAction(GenericShip ship)
         {
             string ShipMessageString = "";
             if (Selection.ThisShip.IsBumped


### PR DESCRIPTION
Updates CollisionRules to call `CheckSkipPerformAction` when movement finishes instead of before Action phase starts, so that a ship is correctly marked to skip its action phase as soon as a bump happens, even if it moves away later (for example, by tractoring from Nantex ship ability).

Fixes #2083 