### PR TITLE
Fix Temmin Wexley + Black One interaction

### DIFF
--- a/Assets/Scripts/Model/Actions/ActionsList/SlamAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/SlamAction.cs
@@ -46,7 +46,12 @@ namespace ActionsList
 
         private void AssignWeaponsDisabledToken()
         {
-            Selection.ThisShip.Tokens.AssignToken(typeof(WeaponsDisabledToken), Phases.CurrentSubPhase.CallBack);
+            Selection.ThisShip.Tokens.AssignToken(typeof(WeaponsDisabledToken), FinishSlam);
+        }
+
+        private void FinishSlam()
+        {
+            Selection.ThisShip.CallSlam(Phases.CurrentSubPhase.CallBack);
         }
 
         private void PerformSlamManeuver(object sender, System.EventArgs e)

--- a/Assets/Scripts/Model/Content/Core/Ship/GenericShipActions.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/GenericShipActions.cs
@@ -82,6 +82,7 @@ namespace Ship
         public static EventHandlerShipTokenBool BeforeRemovingTokenInEndPhaseGlobal;
 
         public event EventHandler OnDecloak;
+        public event EventHandler OnSlam;
 
         public event EventHandlerActionColor OnCheckActionComplexity;
 
@@ -672,6 +673,15 @@ namespace Ship
             if (OnDecloak != null) OnDecloak();
 
             Triggers.ResolveTriggers(TriggerTypes.OnDecloak, callback);
+        }
+
+        // SLAM
+
+        public void CallSlam(Action callback)
+        {
+            if (OnSlam != null) OnSlam();
+
+            Triggers.ResolveTriggers(TriggerTypes.OnSlam, callback);
         }
 
         public ActionColor CallOnCheckActionComplexity(GenericAction action, ref ActionColor color)

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Title/BlackOne.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Title/BlackOne.cs
@@ -39,13 +39,13 @@ namespace Abilities.SecondEdition
         public override void ActivateAbility()
         {
             HostShip.OnTryAddAction += RestrictSlam;
-            HostShip.OnActionIsPerformed += LoseCharge;
+            HostShip.OnSlam += LoseCharge;
         }
 
         public override void DeactivateAbility()
         {
             HostShip.OnTryAddAction -= RestrictSlam;
-            HostShip.OnActionIsPerformed -= LoseCharge;
+            HostShip.OnSlam -= LoseCharge;
         }
 
         private void RestrictSlam(GenericShip ship, GenericAction action, ref bool canBeUsed)
@@ -56,13 +56,13 @@ namespace Abilities.SecondEdition
             }
         }
 
-        private void LoseCharge(GenericAction action)
+        private void LoseCharge()
         {
-            if (action is SlamAction && HostUpgrade.State.Charges > 0)
+            if (HostUpgrade.State.Charges > 0)
             {
                 HostUpgrade.State.LoseCharge();
-                RegisterAbilityTrigger(TriggerTypes.OnActionIsPerformed, AskToReplaceToken);
-            };
+                RegisterAbilityTrigger(TriggerTypes.OnSlam, AskToReplaceToken);
+            }
         }
 
         private void AskToReplaceToken(object sender, System.EventArgs e)

--- a/Assets/Scripts/Model/Tools/Triggers.cs
+++ b/Assets/Scripts/Model/Tools/Triggers.cs
@@ -59,6 +59,7 @@ public enum TriggerTypes
     OnRerollIsConfirmed,
     OnDieResultIsSpent,
     OnDecloak,
+    OnSlam,
 
     OnAttackStart,
     OnShotStart,


### PR DESCRIPTION
As reported in #1753, Black One's `OnActionIsPerformed` event was not triggering when Temmin Wexley's ability triggered.

Root cause: when SLAM is used to do a speed 2-4 maneuver, Temmin's ability is triggered and calls `HostShip.AskPerformFreeAction` to give the player the option of doing a free Boost.  If the player accepts, `ActionsHolder.CurrentAction` is set to the Boost action.  If the player skips, `ActionsHolder.CurrentAction` is set to null.  Either way, Black One's `OnActionIsPerformed` event will not be properly triggered with the SLAM action.

The simplest fix I could think of was to create a new `OnSlam` trigger, similar to `OnDecloak`, and use that instead in the SLAM action and Black One.

Fixes #1753