### PR TITLE
Fix Norra Wexley + C-3PO interaction

### DIFF
--- a/Assets/Scripts/Model/Board/Dice/DiceRoll.cs
+++ b/Assets/Scripts/Model/Board/Dice/DiceRoll.cs
@@ -84,7 +84,7 @@ public partial class DiceRoll
 
     public Die AddDice(DieSide side = DieSide.Unknown)
     {
-        Die newDice = new Die(this, Type, side, isAdded: true);
+        Die newDice = new Die(this, Type, side);
         DiceList.Add(newDice);
         return newDice;
     }

--- a/Assets/Scripts/Model/Board/Dice/DiceRoll.cs
+++ b/Assets/Scripts/Model/Board/Dice/DiceRoll.cs
@@ -84,7 +84,7 @@ public partial class DiceRoll
 
     public Die AddDice(DieSide side = DieSide.Unknown)
     {
-        Die newDice = new Die(this, Type, side);
+        Die newDice = new Die(this, Type, side, isAdded: true);
         DiceList.Add(newDice);
         return newDice;
     }

--- a/Assets/Scripts/Model/Board/Dice/Die.cs
+++ b/Assets/Scripts/Model/Board/Dice/Die.cs
@@ -8,7 +8,7 @@ public partial class Die
     public bool IsRerolled { get; set; }
     public bool IsShowRerolledLock { get; private set; }
     public bool IsUncancelable { get; set; }
-    public bool IsAdded { get; set; }
+    public bool IsAddedResult { get; set; }
 
     private bool cannotBeModified { get; set; }
     public bool CannotBeModified

--- a/Assets/Scripts/Model/Board/Dice/Die.cs
+++ b/Assets/Scripts/Model/Board/Dice/Die.cs
@@ -8,6 +8,7 @@ public partial class Die
     public bool IsRerolled { get; set; }
     public bool IsShowRerolledLock { get; private set; }
     public bool IsUncancelable { get; set; }
+    public bool IsAdded { get; set; }
 
     private bool cannotBeModified { get; set; }
     public bool CannotBeModified

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/C3PORebel.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/C3PORebel.cs
@@ -5,6 +5,7 @@ using SubPhases;
 using Actions;
 using Tokens;
 using System;
+using System.Linq;
 
 namespace UpgradesList.SecondEdition
 {
@@ -100,7 +101,7 @@ namespace Abilities.SecondEdition
             );
 
             selectionSubPhase.DescriptionShort = "C-3PO";
-            selectionSubPhase.DescriptionLong = String.Format("You may choose a number greater than 1. If you roll exactly that many evade results, add 1 evade result.");
+            selectionSubPhase.DescriptionLong = String.Format("You may choose a number 1 or higher. If you roll exactly that many evade results, add 1 evade result.");
             selectionSubPhase.ImageSource = HostUpgrade;
 
             for (var i = 1; i <= 6; i++) //TODO: likely needs to be more than 6, add a way to increase numbers
@@ -124,7 +125,8 @@ namespace Abilities.SecondEdition
 
         private void CheckGuess(DiceRoll diceroll)
         {
-            if(numberGuessed == diceroll.Successes)
+            //compare number guessed to successes rolled (not added)
+            if (numberGuessed == diceroll.DiceList.Count(n => n.IsSuccess && n.IsAdded == false))
             {
                 AddEvadeDie(diceroll);
             } 

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/C3PORebel.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/C3PORebel.cs
@@ -126,7 +126,7 @@ namespace Abilities.SecondEdition
         private void CheckGuess(DiceRoll diceroll)
         {
             //compare number guessed to successes rolled (not added)
-            if (numberGuessed == diceroll.DiceList.Count(n => n.IsSuccess && n.IsAdded == false))
+            if (numberGuessed == diceroll.DiceList.Count(n => n.IsSuccess && !n.IsAddedResult))
             {
                 AddEvadeDie(diceroll);
             } 

--- a/Assets/Scripts/View/Board/Dice/Die.cs
+++ b/Assets/Scripts/View/Board/Dice/Die.cs
@@ -57,12 +57,11 @@ public partial class Die
     public GameObject Model { get; private set; }
     public bool IsWaitingForNewResult { get; set; }
 
-    public Die(DiceRoll diceRoll, DiceKind type, DieSide side = DieSide.Unknown, bool isAdded = false)
+    public Die(DiceRoll diceRoll, DiceKind type, DieSide side = DieSide.Unknown)
     {
         ParentDiceRoll = diceRoll;
         Type = type;
         IsUncancelable = false;
-        IsAdded = isAdded;
         Sides = new List<DieSide>
         {
             DieSide.Blank,
@@ -80,10 +79,12 @@ public partial class Die
         if (side != DieSide.Unknown)
         {
             Side = side;
+            IsAddedResult = true;
         }
         else
         {
             Side = Sides[UnityEngine.Random.Range(0, 8)];
+            IsAddedResult = false;
         }
     }
 

--- a/Assets/Scripts/View/Board/Dice/Die.cs
+++ b/Assets/Scripts/View/Board/Dice/Die.cs
@@ -57,11 +57,12 @@ public partial class Die
     public GameObject Model { get; private set; }
     public bool IsWaitingForNewResult { get; set; }
 
-    public Die(DiceRoll diceRoll, DiceKind type, DieSide side = DieSide.Unknown)
+    public Die(DiceRoll diceRoll, DiceKind type, DieSide side = DieSide.Unknown, bool isAdded = false)
     {
         ParentDiceRoll = diceRoll;
         Type = type;
         IsUncancelable = false;
+        IsAdded = isAdded;
         Sides = new List<DieSide>
         {
             DieSide.Blank,


### PR DESCRIPTION
Adds an `IsAddedResult` property to dice (set to true for dice results that were directly added by an ability like Norra Wexley's), so abilities like C-3PO can include/exclude them as needed.

Fixes #1901