### PR TITLE
fix Collision Detector + repositioning interaction

### DIFF
--- a/Assets/Scripts/Model/Actions/ActionsList/BoostAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/BoostAction.cs
@@ -457,7 +457,7 @@ namespace SubPhases
 
         public override void Next()
         {
-            TheShip.FinishPosition(FinishBoostAnimation);
+            TheShip.ExecutePosition(FinishBoostAnimation);
         }
 
         protected virtual void FinishBoostAnimation()

--- a/Assets/Scripts/Model/Content/Core/Ship/GenericShipMovement.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/GenericShipMovement.cs
@@ -96,6 +96,8 @@ namespace Ship
         public static event EventHandlerShip OnMovementFinishGlobal;
         public static event EventHandlerShip OnMovementFinishSuccessfullyGlobal;
 
+        public event EventHandlerShip OnPositionExecuted;
+        public static event EventHandlerShip OnPositionExecutedGlobal;
         public event EventHandlerShip OnPositionFinish;
         public static event EventHandlerShip OnPositionFinishGlobal;
 
@@ -195,6 +197,20 @@ namespace Ship
                 TriggerTypes.OnMovementFinish,
                 delegate () {
                     Roster.HideAssignedManeuverDial(this);
+                    Selection.ThisShip.ExecutePosition(callback);
+                }
+            );
+        }
+
+        public void ExecutePosition(System.Action callback)
+        {
+            if (OnPositionExecuted != null) OnPositionExecuted(this);
+            if (OnPositionExecutedGlobal != null) OnPositionExecutedGlobal(this);
+
+            Triggers.ResolveTriggers(
+                TriggerTypes.OnPositionExecuted,
+                delegate ()
+                {
                     Selection.ThisShip.FinishPosition(callback);
                 }
             );

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/System/CollisionDetector.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/System/CollisionDetector.cs
@@ -36,7 +36,7 @@ namespace Abilities.SecondEdition
             HostShip.IsIgnoreObstaclesDuringBoost = true;
             HostShip.IsIgnoreObstaclesDuringBarrelRoll = true;
 
-            HostShip.OnMovementExecuted += TryRegisterAbility;
+            HostShip.OnPositionExecuted += TryRegisterAbility;
         }
 
         public override void DeactivateAbility()
@@ -44,7 +44,7 @@ namespace Abilities.SecondEdition
             HostShip.IsIgnoreObstaclesDuringBoost = false;
             HostShip.IsIgnoreObstaclesDuringBarrelRoll = false;
 
-            HostShip.OnMovementExecuted -= TryRegisterAbility;
+            HostShip.OnPositionExecuted -= TryRegisterAbility;
         }
 
         private void TryRegisterAbility(GenericShip ship)
@@ -54,7 +54,7 @@ namespace Abilities.SecondEdition
                 foreach (GenericObstacle obstacle in HostShip.ObstaclesHit)
                 {
                     ObstaclesHit.Add(obstacle);
-                    RegisterAbilityTrigger(TriggerTypes.OnMovementExecuted, ActivateCollisionDetectorAbility);
+                    RegisterAbilityTrigger(TriggerTypes.OnPositionExecuted, ActivateCollisionDetectorAbility);
                 }
             }
         }

--- a/Assets/Scripts/Model/Phases/SubPhases/Temporary/BarrelRollSubPhases.cs
+++ b/Assets/Scripts/Model/Phases/SubPhases/Temporary/BarrelRollSubPhases.cs
@@ -726,7 +726,7 @@ namespace SubPhases
             MovementTemplates.HideLastMovementRuler();
 
             TheShip.ToggleShipStandAndPeg(true);
-            TheShip.FinishPosition(FinishBarrelRollAnimationPart2);
+            TheShip.ExecutePosition(FinishBarrelRollAnimationPart2);
         }
 
         protected virtual void FinishBarrelRollAnimationPart2()

--- a/Assets/Scripts/Model/Rules/RulesList/ObstaclesHitRule.cs
+++ b/Assets/Scripts/Model/Rules/RulesList/ObstaclesHitRule.cs
@@ -18,7 +18,7 @@ namespace RulesList
         {
             if (!RuleIsInitialized)
             {
-                GenericShip.OnMovementFinishGlobal += CheckHits;
+                GenericShip.OnPositionFinishGlobal += CheckHits;
                 RuleIsInitialized = true;
             }
         }
@@ -35,7 +35,7 @@ namespace RulesList
                     {
                         Name = "Apply effect of hit obstacle",
                         TriggerOwner = ship.Owner.PlayerNo,
-                        TriggerType = TriggerTypes.OnMovementFinish,
+                        TriggerType = TriggerTypes.OnPositionFinish,
                         EventHandler = delegate { obstacle.OnHit(ship); }
                     });
                 }

--- a/Assets/Scripts/Model/Tools/Triggers.cs
+++ b/Assets/Scripts/Model/Tools/Triggers.cs
@@ -39,6 +39,7 @@ public enum TriggerTypes
     OnMovementStart,
     OnMovementExecuted,
     OnMovementFinish,
+    OnPositionExecuted,
     OnPositionFinish,
     
     OnFreeActionPlanned,


### PR DESCRIPTION
Fix issue where Collision Detector wasn't triggered when barrel rolling/boosting thru obstacles.  Root cause was that CD was triggered by `OnMovementExecuted`, but barrel roll/boost actions were calling `TheShip.FinishPosition`, which doesn't trigger `OnMovementExecuted`.

Fixed by creating an `OnPositionExecuted` trigger (which happens just before `OnPositionFinish`) and using that in CD and barrel roll/boost actions.  Also changed the trigger for the obstacles hit rule to `OnPositionFinish` to ensure CD is triggered before the check for obstacles hit effects.

Fixes #1377
Fixes #1654