### PR TITLE
Fix some bomb drop issues

### DIFF
--- a/Assets/Scripts/Model/Combat/Bombs.cs
+++ b/Assets/Scripts/Model/Combat/Bombs.cs
@@ -285,8 +285,6 @@ namespace Bombs
 
             selectBombToDrop.RequiredPlayer = Selection.ThisShip.Owner.PlayerNo;
 
-            selectBombToDrop.IsForced = true;
-
             selectBombToDrop.Start();
         }
 


### PR DESCRIPTION
Fixes the first (ship w/ 1 device drops it automatically when activated during System Phase) and third (ship w/ multiple devices drops the first device automatically when activated during System Phase) issues reported in #2141 .