### PR TITLE
Fix Duchess ability

### DIFF
--- a/Assets/Scripts/Model/Content/FirstEdition/Upgrades/Title/AdaptiveAilerons.cs
+++ b/Assets/Scripts/Model/Content/FirstEdition/Upgrades/Title/AdaptiveAilerons.cs
@@ -101,7 +101,8 @@ namespace Abilities.FirstEdition
                     UseAbility,
                     DontUseAbility,
                     descriptionLong: "Do you want to skip activation of your Adaptive Ailerons?",
-                    imageHolder: HostShip
+                    imageHolder: HostShip,
+                    showSkipButton: false
                 );
             }
             else

--- a/Assets/Scripts/Model/Content/FirstEdition/Upgrades/Title/AdaptiveAilerons.cs
+++ b/Assets/Scripts/Model/Content/FirstEdition/Upgrades/Title/AdaptiveAilerons.cs
@@ -35,7 +35,7 @@ namespace Abilities.FirstEdition
         private static readonly List<string> ChangedManeuversCodes = new List<string>() { "1.L.B", "1.F.S", "1.R.B" };
         private Dictionary<string, MovementComplexity> SavedManeuverColors;
 
-        bool doAilerons = true;
+        bool doAilerons = false;
 
         public override void ActivateAbility()
         {
@@ -97,12 +97,11 @@ namespace Abilities.FirstEdition
             {
                 AskToUseAbility(
                     HostShip.PilotInfo.PilotName,
-                    AlwaysUseByDefault,
-                    UseAbility,
-                    DontUseAbility,
-                    descriptionLong: "Do you want to skip activation of your Adaptive Ailerons?",
-                    imageHolder: HostShip,
-                    showSkipButton: false
+                    NeverUseByDefault,
+                    UseAilerons,
+                    DontUseAilerons,
+                    descriptionLong: "Do you want to activate your Adaptive Ailerons?",
+                    imageHolder: HostShip
                 );
             }
             else
@@ -111,14 +110,14 @@ namespace Abilities.FirstEdition
             }
         }
 
-        private void UseAbility(object sender, EventArgs e)
+        private void DontUseAilerons(object sender, EventArgs e)
         {
-            doAilerons = false;
             DecisionSubPhase.ConfirmDecision();
         }
 
-        private void DontUseAbility(object sender, EventArgs e)
+        private void UseAilerons(object sender, EventArgs e)
         {
+            doAilerons = true;
             DecisionSubPhase.ConfirmDecisionNoCallback();
             SelectAdaptiveAileronsManeuver(sender, e);
         }


### PR DESCRIPTION
Fixes bug with Duchess ability where skipping it results in the chosen maneuver being executed twice.  Also fixes Duchess ability dialog to remove a confusing double-negative, and make the YES/NO/SKIP semantics consistent with other ability dialogs.

Fixes #2195 (fixes double-negative in Duchess ability dialog)
Fixes #2197 (extra maneuver when Duchess ability is skipped)