### PR TITLE
Fix Saw crew ability

### DIFF
--- a/Assets/Scripts/Model/Content/FirstEdition/Upgrades/Crew/SawGerrera.cs
+++ b/Assets/Scripts/Model/Content/FirstEdition/Upgrades/Crew/SawGerrera.cs
@@ -62,7 +62,13 @@ namespace ActionsList
         public override bool IsDiceModificationAvailable()
         {
             bool result = false;
-            if (Combat.AttackStep == CombatStep.Attack && HostShip.State.HullCurrent > 1) result = true;
+
+            if (Combat.AttackStep == CombatStep.Attack)
+            {
+                int attackFocuses = Combat.DiceRollAttack.Focuses;
+                if (attackFocuses > 0) result = true;
+            }
+
             return result;
         }
 


### PR DESCRIPTION
Make Saw crew ability available if there's at least 1 Focus result to modify.

Fixes #2224