### PR TITLE
Make Novice Technician skippable again

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/NoviceTechnician.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/NoviceTechnician.cs
@@ -91,8 +91,6 @@ namespace Abilities.SecondEdition
 
             public override void PrepareDecision(Action callBack)
             {
-                ShowSkipButton = false;
-
                 DecisionViewType = DecisionViewTypes.ImagesDamageCard;
 
                 if (HostShip.Damage.HasFaceupCards)


### PR DESCRIPTION
The ability is a `may`, so it should be skippable.

Fixes issue reported by https://community.fantasyflightgames.com/topic/267459-fly-casual-x-wing-simulator/page/60/?tab=comments#comment-3760480