### PR TITLE
AI should only use Elusive when there's at least 1 failure to reroll

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/Elusive.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/Elusive.cs
@@ -58,7 +58,11 @@ namespace Abilities.SecondEdition
         {
             int result = 0;
 
-            if (Combat.DiceRollAttack.Successes > Combat.DiceRollDefence.Successes) result = 85;
+            if (Combat.DiceRollAttack.Successes > Combat.DiceRollDefence.Successes
+                && Combat.DiceRollDefence.Failures > 0)
+            {
+                result = 85;
+            }
 
             return result;
         }


### PR DESCRIPTION
Fixes #2235 