### PR TITLE
Fix blue movement through debris

### DIFF
--- a/Assets/Scripts/Model/Actions/ActionsList/BoostAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/BoostAction.cs
@@ -327,7 +327,6 @@ namespace SubPhases
             {
                 CheckMines();
                 TheShip.ObstaclesLanded = new List<GenericObstacle>(obstaclesStayDetectorBase.OverlappedAsteroidsNow);
-                TheShip.ObstaclesHit = new List<GenericObstacle>(obstaclesStayDetectorBase.OverlappedAsteroidsNow);
                 obstaclesStayDetectorMovementTemplate.OverlappedAsteroidsNow
                     .Where((a) => !TheShip.ObstaclesHit.Contains(a)).ToList()
                     .ForEach(TheShip.ObstaclesHit.Add);

--- a/Assets/Scripts/Model/Content/Core/Ship/GenericShipMovement.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/GenericShipMovement.cs
@@ -198,7 +198,7 @@ namespace Ship
                 TriggerTypes.OnMovementFinish,
                 delegate () {
                     Roster.HideAssignedManeuverDial(this);
-                    callback();
+                    Selection.ThisShip.CallPositionIsReadyToFinish(callback);
                 }
             );
         }

--- a/Assets/Scripts/Model/Movement/MovementTypes/GenericMovement.cs
+++ b/Assets/Scripts/Model/Movement/MovementTypes/GenericMovement.cs
@@ -187,9 +187,7 @@ namespace Movement
         {
             MovementTemplates.HideLastMovementRuler();
 
-            Selection.ActiveShip.CallPositionIsReadyToFinish(delegate {
-                Selection.ActiveShip.CallExecuteMoving(Triggers.FinishTrigger);
-            });
+            Selection.ActiveShip.CallExecuteMoving(Triggers.FinishTrigger);
         }
 
         protected virtual void ManeuverEndRotation(Action callBack)

--- a/Assets/Scripts/Model/Phases/SubPhases/Temporary/BarrelRollSubPhases.cs
+++ b/Assets/Scripts/Model/Phases/SubPhases/Temporary/BarrelRollSubPhases.cs
@@ -595,7 +595,6 @@ namespace SubPhases
         private void SyncCollisions(ObstaclesStayDetectorForced collider)
         {
             TheShip.ObstaclesLanded = new List<GenericObstacle>(collider.OverlappedAsteroidsNow);
-            TheShip.ObstaclesHit = new List<GenericObstacle>(collider.OverlappedAsteroidsNow);
             collider.OverlappedAsteroidsNow
                 .Where((a) => !TheShip.ObstaclesHit.Contains(a)).ToList()
                 .ForEach(TheShip.ObstaclesHit.Add);

--- a/Assets/Scripts/Model/Rules/RulesList/ObstaclesHitRule.cs
+++ b/Assets/Scripts/Model/Rules/RulesList/ObstaclesHitRule.cs
@@ -1,7 +1,6 @@
-﻿using System.Collections;
-using UnityEngine;
+﻿using Obstacles;
 using Ship;
-using SubPhases;
+using System.Collections.Generic;
 
 namespace RulesList
 {
@@ -39,6 +38,9 @@ namespace RulesList
                         EventHandler = delegate { obstacle.OnHit(ship); }
                     });
                 }
+
+                //HACK reset ObstaclesHit to ensure each obstacle hit is only processed once per movement
+                ship.ObstaclesHit = new List<GenericObstacle>();
             }
         }
     }


### PR DESCRIPTION
Reverts the recent change that put `OnPositionFinish` before `OnMovementFinish` (#2187), which was the cause of the blue-maneuver-through-debris issue (#2234).

#2187 was an attempt to fix the interaction of barrel roll/boost and obstacles (#2184), so I implemented the alternative fix we discussed in Slack, updating Barrel Roll & Boost to stop resetting `ObstaclesHit`, which is now done in ObstaclesHitRule (to avoid obstacle hits being triggered multiple times if a ship barrel rolls or boosts after executing a maneuver).

Fixes #2234