### PR TITLE
Fix interaction between tractor beam + Wounded Pilot crit

### DIFF
--- a/Assets/Scripts/Model/Rules/RulesList/TractorBeamRule.cs
+++ b/Assets/Scripts/Model/Rules/RulesList/TractorBeamRule.cs
@@ -183,7 +183,7 @@ namespace SubPhases
                 "Select position",
                 typeof(BarrelRollPlanningSubPhase),
                 delegate {
-                    FinishTractorBeamMovement(stubAction);
+                    FinishTractorBeamMovement();
                 }
             );
             brPlanning.Name = "Select position";
@@ -225,7 +225,7 @@ namespace SubPhases
                 "Boost",
                 typeof(BoostPlanningSubPhase),
                 delegate {
-                    FinishTractorBeamMovement(stubAction);
+                    FinishTractorBeamMovement();
                 }
             );
             boostPlanning.HostAction = stubAction;
@@ -276,13 +276,10 @@ namespace SubPhases
             selectTractorDirection.Start();
         }
 
-        private void FinishTractorBeamMovement(GenericAction action)
+        private void FinishTractorBeamMovement()
         {
-            TheShip.CallActionIsTaken(action, delegate {
-                // ^ CallActionIsTaken to support interaction with black one, etc
-                Rules.AsteroidHit.CheckHits(TheShip);
-                Triggers.ResolveTriggers(TriggerTypes.OnMovementFinish, Next);
-            });
+            Rules.AsteroidHit.CheckHits(TheShip);
+            Triggers.ResolveTriggers(TriggerTypes.OnMovementFinish, Next);
         }
 
         public override void Next()


### PR DESCRIPTION
Removes firing of `OnActionIsPerformed` trigger after a tractor-induced barrel roll/boost, because those are not considered real actions in either 1E or 2E (and therefore should not trigger post-action-performed abilities such as 1E Black One).

Fixes #2209