### PR TITLE
Tweak AI usage of Rebel Hans ability

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/ModifiedYT1300LightFreighter/HanSolo.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/ModifiedYT1300LightFreighter/HanSolo.cs
@@ -59,7 +59,15 @@ namespace Abilities.SecondEdition
 
         private int GetAiPriority()
         {
-            return 95;
+            if (HostShip.IsAttacking && Combat.DiceRollAttack.Failures > Combat.DiceRollAttack.Successes)
+            {
+                return 95;
+            }
+            else if (HostShip.IsDefending && Combat.DiceRollDefence.Failures > Combat.DiceRollDefence.Successes)
+            {
+                return 95;
+            }
+            else return 0;
         }
 
         public override void DeactivateAbility()


### PR DESCRIPTION
Tries to make AI a bit wiser w.r.t. Rebel Hans ability, using the reroll only if # of failures > # of successes rolled.

Fixes #2249