### PR TITLE
Fix Anakin (Aethersprite) ability

### DIFF
--- a/Assets/Scripts/Model/Content/Core/Ship/Arcs/SectorsHolder.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/Arcs/SectorsHolder.cs
@@ -71,7 +71,17 @@ namespace Ship
         public int RangeToShipBySector(GenericShip anotherShip, ArcType arcType)
         {
             ShotInfoArc arcInfo = GetSectorInfo(anotherShip, arcType);
-            return (arcInfo != null) ? arcInfo.Range : int.MaxValue;
+            if (arcInfo != null)
+            {
+                bool result = arcInfo.IsShotAvailable;
+                if (arcType == ArcType.Bullseye) HostShip.CallOnBullseyeArcCheck(anotherShip, ref result);
+
+                return result ? arcInfo.Range : int.MaxValue;
+            }
+            else
+            {
+                return int.MaxValue;
+            }
         }
 
         public ShotInfoArc GetSectorInfo(GenericShip anotherShip, ArcType arcType)

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Delta7Aethersprite/AnakinSkywalker.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Delta7Aethersprite/AnakinSkywalker.cs
@@ -51,7 +51,7 @@ namespace Abilities.SecondEdition
 
         private void RegisterCheckAnakinAbility(GenericShip ship)
         {
-            if (isAnakinAbilityAvailable(HostShip) && HostShip.IsStressed == true)
+            if (HostShip.IsStressed == true)
             {
                 RegisterAbilityTrigger(TriggerTypes.OnMovementFinish, AskToUseAnakin);
             }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Delta7Aethersprite/AnakinSkywalker.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Delta7Aethersprite/AnakinSkywalker.cs
@@ -51,7 +51,7 @@ namespace Abilities.SecondEdition
 
         private void RegisterCheckAnakinAbility(GenericShip ship)
         {
-            if (HostShip.IsStressed == true)
+            if (isAnakinAbilityAvailable(HostShip) && HostShip.IsStressed == true)
             {
                 RegisterAbilityTrigger(TriggerTypes.OnMovementFinish, AskToUseAnakin);
             }
@@ -91,8 +91,7 @@ namespace Abilities.SecondEdition
                 int enemies = 0;
                 enemies += Board.GetShipsInBullseyeArc(HostShip, Team.Type.Enemy).Count;
                 foreach(var s in Board.GetShipsAtRange(HostShip, new Vector2(0,1), Team.Type.Enemy)) {
-                    if (HostShip.SectorsInfo.IsShipInSector(s, Arcs.ArcType.Front) &&
-                        HostShip.SectorsInfo.RangeToShipBySector(s, Arcs.ArcType.Front) <= 1) {
+                    if (HostShip.SectorsInfo.RangeToShipBySector(s, Arcs.ArcType.Front) <= 1) {
                         enemies++;
                     }
                 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/Delta7Aethersprite/AnakinSkywalker.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/Delta7Aethersprite/AnakinSkywalker.cs
@@ -91,7 +91,8 @@ namespace Abilities.SecondEdition
                 int enemies = 0;
                 enemies += Board.GetShipsInBullseyeArc(HostShip, Team.Type.Enemy).Count;
                 foreach(var s in Board.GetShipsAtRange(HostShip, new Vector2(0,1), Team.Type.Enemy)) {
-                    if (HostShip.SectorsInfo.RangeToShipBySector(s, Arcs.ArcType.Front) <= 1) {
+                    if (HostShip.SectorsInfo.IsShipInSector(s, Arcs.ArcType.Front) &&
+                        HostShip.SectorsInfo.RangeToShipBySector(s, Arcs.ArcType.Front) <= 1) {
                         enemies++;
                     }
                 }

--- a/Assets/Scripts/Model/Content/SecondEdition/Ships/Delta7Aethersprite.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Ships/Delta7Aethersprite.cs
@@ -113,7 +113,7 @@ namespace Abilities.SecondEdition
 
         private void RegisterTrigger(GenericShip ship)
         {
-            if (HostShip.State.Force > 0 && !(HostShip.IsStressed || Board.IsOffTheBoard(HostShip) || HostShip.IsBumped))
+            if (HostShip.State.Force > 0 && !(Board.IsOffTheBoard(HostShip) || HostShip.IsBumped))
             {
                 RegisterAbilityTrigger(TriggerTypes.OnMovementFinish, AskPerformRepositionAction);
             }
@@ -121,7 +121,7 @@ namespace Abilities.SecondEdition
         
         private void AskPerformRepositionAction(object sender, System.EventArgs e)
         {
-            if (HostShip.State.Force > 0)
+            if (HostShip.State.Force > 0 && !HostShip.IsStressed)
             {
                 HostShip.BeforeActionIsPerformed += PayForceCost;
 


### PR DESCRIPTION
Fixes issues reported in https://community.fantasyflightgames.com/topic/267459-fly-casual-x-wing-simulator/page/63/?tab=comments#comment-3775767:

- fix "is enemy ship in front arc at range 1?" check by updating `SectorsInfo.RangeToShipBySector` so it only returns range if ship is actually in sector.  I verified all other calls to `SectorsInfo.RangeToShipBySector`, they already use `SectorsInfo.IsShipInSector` as an additional check, so this change should not cause any problems.
- update Fine-Tuned Controls so that when Anakin k-turns or s-loops, the player can use Anakin's ability to shed stress and then use Fine-Tuned Controls.