### PR TITLE
Special Weapons from Illicit and Talent upgrades should not be treated as primary weapons

### DIFF
--- a/Assets/Scripts/Model/Content/Core/Ship/GenericShipCombat.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/GenericShipCombat.cs
@@ -19,7 +19,8 @@ namespace Ship
         Missile,
         Cannon,
         Turret,
-        Illicit
+        Illicit,
+        Talent
     }
 
     public partial class GenericShip

--- a/Assets/Scripts/Model/Content/Core/Upgrade/SpecialWeapon/GenericSpecialWeapon.cs
+++ b/Assets/Scripts/Model/Content/Core/Upgrade/SpecialWeapon/GenericSpecialWeapon.cs
@@ -39,6 +39,14 @@ namespace Upgrade
                 {
                     weaponType = WeaponTypes.Turret;
                 }
+                else if (UpgradeInfo.HasType(UpgradeType.Illicit))
+                {
+                    weaponType = WeaponTypes.Illicit;
+                }
+                else if (UpgradeInfo.HasType(UpgradeType.Talent))
+                {
+                    weaponType = WeaponTypes.Talent;
+                }
 
                 return weaponType;
             }


### PR DESCRIPTION
Fixes #2317 

This code should probably be reworked. Whether a weapon is primary or not should not be inferred from upgrade type