### PR TITLE
Fix Ruthless sometimes not damaging friendly ship

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/Ruthless.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/Ruthless.cs
@@ -137,7 +137,7 @@ namespace ActionsList
             {
                 // The team argument is relative to the ship it's measuring from, not the host of this ability, so we need to query for enemies of the defender
                 List<GenericShip> friendlyShipsAtRange1FromTarget = Board.GetShipsAtRange(Combat.Defender, new Vector2(0, 1), Team.Type.Enemy);
-                if (friendlyShipsAtRange1FromTarget.Any(n => n.ShipId != HostShip.ShipId && n.State.HullCurrent > 0)) result = 33;
+                if (friendlyShipsAtRange1FromTarget.Any(n => n.ShipId != HostShip.ShipId && n.State.HullCurrent > 1)) result = 33;
             }
 
             return result;


### PR DESCRIPTION
Fixes loophole in Ruthless AI logic, where if the only enemy ship within range 1 of the target has exactly 1 health, the AI will use the Ruthless dice modification but not damage that friendly ship.

Fixes #2341 