### PR TITLE
Zuckuss ability should only assign stress if a die was actually rerolled

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/Zuckuss.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/Zuckuss.cs
@@ -85,7 +85,10 @@ namespace ActionsList
                 NumberOfDiceCanBeRerolled = 1,
                 IsOpposite = true,
                 CallBack = delegate {
-                    AssignStress(callBack);
+                    if (Combat.CurrentDiceRoll.DiceRerolled.Any())
+                        AssignStress(callBack);
+                    else
+                        callBack();
                 }
             };
             diceRerollManager.Start();


### PR DESCRIPTION
Fixes #2387 