### PR TITLE
Added the missing reload action to the Decimator

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Ships/VT49Decimator.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Ships/VT49Decimator.cs
@@ -18,6 +18,7 @@ namespace Ship.SecondEdition.VT49Decimator
 
             ShipInfo.ActionIcons.AddActions(new ActionInfo(typeof(ReinforceAction)));
             ShipInfo.ActionIcons.AddActions(new ActionInfo(typeof(RotateArcAction)));
+            ShipInfo.ActionIcons.AddActions(new ActionInfo(typeof(ReloadAction)));
             ShipInfo.ActionIcons.AddActions(new ActionInfo(typeof(CoordinateAction), ActionColor.Red));
 
             DialInfo.AddManeuver(new ManeuverHolder(ManeuverSpeed.Speed1, ManeuverDirection.Left, ManeuverBearing.Turn), MovementComplexity.Complex);


### PR DESCRIPTION
The VT-49 Decimator in 2.0 is unable to reload even though it has a reload action on the action bar. I believe this fixes it.