### PR TITLE
Mid game setup: set default rotation based on which side the ship is entering from

### DIFF
--- a/Assets/Scripts/Model/Phases/SubPhases/Temporary/SetupShipMidgameSubPhase.cs
+++ b/Assets/Scripts/Model/Phases/SubPhases/Temporary/SetupShipMidgameSubPhase.cs
@@ -50,12 +50,29 @@ namespace SubPhases
 
             Board.ToggleOffTheBoardHolder(false);
 
-            Board.SetShipPreSetup(ShipToSetup);
+            Board.SetShipPreSetup(ShipToSetup, 1, GetDefaulRotationForSetupSide());
 
             Roster.HighlightShipsFiltered(FilterShipsToSetup);
 
             IsReadyForCommands = true;
             Roster.GetPlayer(RequiredPlayer).SetupShipMidgame();
+        }
+
+        private float GetDefaulRotationForSetupSide()
+        {
+            switch (SetupSide)
+            {
+                case Direction.Bottom:
+                    return 0;
+                case Direction.Left:
+                    return 90;
+                case Direction.Top:
+                    return 180;
+                case Direction.Right:
+                    return 270;
+                default:
+                    return 0;
+            }
         }
 
         public void ShowDescription()

--- a/Assets/Scripts/View/Board/Board.cs
+++ b/Assets/Scripts/View/Board/Board.cs
@@ -96,7 +96,7 @@ namespace BoardTools
             DynamicGI.UpdateEnvironment();
         }
 
-        public static void SetShipPreSetup(GenericShip ship, int count = 1)
+        public static void SetShipPreSetup(GenericShip ship, int count = 1, float? rotation = null)
         {
             float distance = CalculateDistance(ship.Owner.Ships.Count);
             float side = (ship.Owner.PlayerNo == Players.PlayerNo.Player1) ? -1 : 1;
@@ -111,10 +111,12 @@ namespace BoardTools
                 )
             );
 
+            if (rotation == null) rotation = (ship.Owner.PlayerNo == Players.PlayerNo.Player1) ? 0 : 180;
+
             ship.SetAngles(
                 new Vector3(
                     ship.GetAngles().x,
-                    (ship.Owner.PlayerNo == Players.PlayerNo.Player1) ? 0 : 180,
+                    rotation.Value,
                     ship.GetAngles().z
                 )
             );


### PR DESCRIPTION
Especially useful on mobile devices where rotation is a bit difficult

related to #2451 