### PR TITLE
UpgradeBarRestriction should use actual upgrade slots on ship, not printed

### DIFF
--- a/Assets/Scripts/Model/Content/Core/Upgrade/UpgradeCardRestrictions.cs
+++ b/Assets/Scripts/Model/Content/Core/Upgrade/UpgradeCardRestrictions.cs
@@ -55,7 +55,7 @@ namespace Upgrade
         {
             foreach (UpgradeType upgrade in UpgradeSlots)
             {
-                if (!ship.ShipInfo.UpgradeIcons.Upgrades.Contains(upgrade)) return false;
+                if (!ship.UpgradeBar.GetUpgradeSlots().Any(slot => slot.Type == upgrade)) return false;
             }
 
             return true;


### PR DESCRIPTION

Fixes #2431 