### PR TITLE
Fixed Bug that caused crash after Deathfires onDeath Attack

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIESaBomber/Deathfire.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIESaBomber/Deathfire.cs
@@ -77,8 +77,13 @@ namespace Abilities.SecondEdition
         private void DoAttack(object sender, System.EventArgs e)
         {
             DecisionSubPhase.ConfirmDecisionNoCallback();
-
-            Combat.StartSelectAttackTarget(HostShip, Triggers.FinishTrigger, abilityName: "Attack", description: "Select target");
+            GenericShip AttackerBeforeAbility = Combat.Attacker;
+            GenericShip DefenderBeforeAbility = Combat.Defender;
+            Combat.StartSelectAttackTarget(HostShip, () => {
+                Combat.Attacker = AttackerBeforeAbility;
+                Combat.Defender = DefenderBeforeAbility;
+                Triggers.FinishTrigger();
+            }, abilityName: "Attack", description: "Select target");
         }
 
         private void DropBomb(object sender, System.EventArgs e)


### PR DESCRIPTION
Deathfire caused the game to crash after his OnDeath Attack, as described in this issue: https://github.com/Sandrem/FlyCasual/issues/2872
I was able to reproduce the problem and it also happened if I only had Deathfire in my squad -> he got shot down and the game crashed before it could go to the defeat screen.

Problem: After the attack performed by Deathfire as part of his OnDeath triggered ability, "CleanupCombatData()" Function of the Combat class was executed, resetting everything in the Combat class. After the trigger, the original attack that caused his death went to the "CheckMissedAttack()" function, causing a nullpointer exception since Attacker and Defender were both null after the Cleanup caused by Deathfire's attack.

Solution: I am caching the Attacker and Defender and then reset them to the original value after Deathfire finishes his action. This allows the attacker to go through the usual CheckMissedAttack / FinishAttack steps.

I successfully tested the solution 2x with Deathfire alone and 2x with a Lambda Shuttle with Admiral Sloane on board.