### PR TITLE
Mining guild barrel asteroid

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Ships/ModifiedTIELnFighter.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Ships/ModifiedTIELnFighter.cs
@@ -22,8 +22,6 @@ namespace Ship
 
                 ShipAbilities.Add(new Abilities.SecondEdition.ModifiedTIELnFighterAbility());
 
-                ShipAbilities.Add(new Abilities.SecondEdition.ModifiedTIELnFighterAbility());
-
                 ModelInfo = new ShipModelInfo(
                     "Modified TIE Fighter",
                     "Mining Guild Yellow",

--- a/Assets/Scripts/Model/Obstacles/Asteroid.cs
+++ b/Assets/Scripts/Model/Obstacles/Asteroid.cs
@@ -20,6 +20,10 @@ namespace Obstacles
 
         public override void OnHit(GenericShip ship)
         {
+            if (Selection.ThisShip.IgnoreObstacleTypes.Contains(typeof(Asteroid))) {
+                return;
+            }
+
             if (!Selection.ThisShip.CanPerformActionsWhenOverlapping)
             {
                 Messages.ShowErrorToHuman(ship.PilotInfo.PilotName + " hit an asteroid during movement, their action subphase is skipped");

--- a/Assets/Scripts/Model/Phases/SubPhases/Temporary/BarrelRollSubPhases.cs
+++ b/Assets/Scripts/Model/Phases/SubPhases/Temporary/BarrelRollSubPhases.cs
@@ -370,7 +370,11 @@ namespace SubPhases
             {
                 BarrelRollProblems.Add(ActionFailReason.Bumped);
             }
-            else if (!TheShip.IsIgnoreObstacles && !TheShip.IsIgnoreObstaclesDuringBarrelRoll && !IsTractorBeamBarrelRoll && collider.OverlapsAsteroidNow)
+            else if (!TheShip.IsIgnoreObstacles 
+                && !TheShip.IsIgnoreObstaclesDuringBarrelRoll 
+                && !IsTractorBeamBarrelRoll 
+                && collider.OverlapsAsteroidNow
+                && !TheShip.IgnoreObstacleTypes.Contains(typeof(Asteroid)))
             {
                 BarrelRollProblems.Add(ActionFailReason.ObstacleHit);
             }


### PR DESCRIPTION
Fixing this issue: https://github.com/Sandrem/FlyCasual/issues/2300

Asteroids no longer apply their onHit effects to ships that ignore asteroid collisions. Barrel roll no longer fails to execute if a ship that ignores asteroid collisions would end up on an asteroid.

I also removed the duplicate application of the Modified Tie/ln while at it, I can make a separate pull request for this if you would  prefer that though.

Fix tested: I played a few games to test the fix and Modified Tie/ln can now move and barrel roll through asteroids all day long but their attacks are still prevented (which is the intent of their ability if I understand it correctly). I made sure they are still blocked by other ships and that other ships still get the negative consequences of moving through an asteroid & are prevented to barrel roll into asteroids.