### PR TITLE
Synced Laser Cannons

### DIFF
--- a/Assets/Scripts/Model/Content/Core/Upgrade/SpecialWeapon/SpecialWeaponInfo.cs
+++ b/Assets/Scripts/Model/Content/Core/Upgrade/SpecialWeapon/SpecialWeaponInfo.cs
@@ -53,7 +53,7 @@ namespace Upgrade
         public bool CanShootOutsideArc { get; private set; }
         public ArcsList ArcRestrictions { get; private set; }
         public bool UsesCharges { get { return Charges > 0; } }
-        public bool NoRangeBonus { get; private set; }
+        public virtual bool NoRangeBonus { get; protected set; }
 
         public SpecialWeaponInfo(int attackValue, int minRange, int maxRange, Type requiresToken = null, Type spendsToken = null, int charges = 0, bool discard = false, bool twinAttack = false, bool canShootOutsideArc = false, ArcType arc = ArcType.Front, bool noRangeBonus = false)
         {

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Cannon/SyncedLaserCannons.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Cannon/SyncedLaserCannons.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using Upgrade;
+
+namespace UpgradesList.SecondEdition
+{
+    public class SyncedLaserCannons : GenericSpecialWeapon
+    {
+        public SyncedLaserCannons() : base()
+        {
+            FromMod = typeof(Mods.ModsList.UnreleasedContentMod);
+
+            UpgradeInfo = new UpgradeCardInfo(
+                "Synced Laser Cannons",
+                types: new List<UpgradeType>()
+                {
+                    UpgradeType.Cannon,
+                    UpgradeType.Cannon
+                },
+                cost: 6, //TODO
+                weaponInfo: new SyncedLaserCannonsWeaponInfo(this)                
+            );
+
+            ImageUrl = "https://images-cdn.fantasyflightgames.com/filer_public/9b/11/9b115a04-a49d-40f0-ac06-5accb903aa5c/swz71_upgrade_synced-cannons.png";
+        }
+
+        private class SyncedLaserCannonsWeaponInfo : SpecialWeaponInfo
+        {
+            private GenericUpgrade HostUpgrade;
+            public SyncedLaserCannonsWeaponInfo(GenericUpgrade hostUpgrade) : base(3, 2, 3)
+            {
+                HostUpgrade = hostUpgrade;
+            }
+                
+            public override bool NoRangeBonus 
+            { 
+                get 
+                {
+                    if (Combat.AttackStep == CombatStep.Defence
+                        && Combat.Attacker == HostUpgrade.HostShip
+                        && HostUpgrade.HostShip.Tokens.HasToken<Tokens.CalculateToken>())
+                        return true;
+                    else 
+                        return false;
+                } 
+            }
+        
+        }
+    }
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Cannon/SyncedLaserCannons.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Cannon/SyncedLaserCannons.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c6da9ee88b442544a029766da4d8535
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
I wasn't 100% sure about how the timing for the ability works, but I have assumed that the check for calculating is done at the Roll Defense Dice step, so that if you spend the calculate on the attack roll, the defender will get the range bonus

![image](https://user-images.githubusercontent.com/11047987/92647739-b159ac80-f2e8-11ea-9c01-15568ee0b4d1.png)
