### PR TITLE
Gravitic Deflection should only count tractored ships, and it should use the attacker's arc, not the host ship.

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/GraviticDeflection.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Talent/GraviticDeflection.cs
@@ -43,8 +43,11 @@ namespace Abilities.SecondEdition
 
             foreach (GenericShip ship in Roster.AllShips.Values)
             {
-                ShotInfoArc inArcCheck = new ShotInfoArc(HostShip, ship, Combat.ArcForShot);
-                if (inArcCheck.InArc) shipsInAttackArc.Add(ship);
+                if (ship.IsTractored)
+                {
+                    ShotInfoArc inArcCheck = new ShotInfoArc(Combat.Attacker, ship, Combat.ArcForShot);
+                    if (inArcCheck.InArc) shipsInAttackArc.Add(ship);
+                }
             }
 
             return shipsInAttackArc.Count;


### PR DESCRIPTION


Fixes #2915