### PR TITLE
Initialize RequiresTokes to an empty list instead of null, to avoid nullreference exceptions

### DIFF
--- a/Assets/Scripts/Model/Content/Core/Upgrade/SpecialWeapon/SpecialWeaponInfo.cs
+++ b/Assets/Scripts/Model/Content/Core/Upgrade/SpecialWeapon/SpecialWeaponInfo.cs
@@ -60,7 +60,7 @@ namespace Upgrade
             AttackValue = attackValue;
             MinRange = minRange;
             MaxRange = maxRange;
-            RequiresTokens = (requiresToken != null) ? new List<Type>() { requiresToken } : requiresTokens;
+            RequiresTokens = (requiresToken != null) ? new List<Type>() { requiresToken } : (requiresTokens != null ? requiresTokens : new List<Type>());
             SpendsToken = spendsToken;
             Discard = discard;
             Charges = charges;


### PR DESCRIPTION
Fixes #2993