### PR TITLE
Fixed problem with cloning a red repair action. 

### DIFF
--- a/Assets/Scripts/Model/Actions/ActionsList/CancelCritAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/CancelCritAction.cs
@@ -24,6 +24,13 @@ namespace ActionsList
             ImageUrl = critCard.ImageUrl;
         }
 
+        public override GenericAction Clone()
+        {
+            var clone = new CancelCritAction();
+            clone.Initialize(CritCard);
+            return clone;
+        }
+
         public override void ActionTake()
         {
             Selection.ActiveShip = Selection.ThisShip;

--- a/Assets/Scripts/Model/Actions/ActionsList/GenericAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/GenericAction.cs
@@ -209,6 +209,11 @@ namespace ActionsList
 
         public virtual void RevertActionOnFail(bool hasSecondChance = false) {}
 
+        //override this for actions that require further initialization
+        public virtual GenericAction Clone()
+        {
+            return (GenericAction)Activator.CreateInstance(GetType());
+        }
     }
 
 }

--- a/Assets/Scripts/Model/Content/Core/Ship/GenericShipActions.cs
+++ b/Assets/Scripts/Model/Content/Core/Ship/GenericShipActions.cs
@@ -135,8 +135,7 @@ namespace Ship
         private GenericAction GetActionAsRed(GenericAction action)
         {
             //Make a deep clone to avoid changing the original action to red
-            GenericAction instance = (GenericAction)Activator.CreateInstance(action.GetType());
-            if (instance.IsCritCancelAction) ((CancelCritAction)instance).Initialize(((CancelCritAction)action).CritCard);
+            GenericAction instance = action.Clone();
             instance.Color = ActionColor.Red;
             return instance;
         }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Astromech/R5Astromech.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Astromech/R5Astromech.cs
@@ -94,6 +94,11 @@ namespace ActionsList
             DiceModificationName = Name = "Repair 1 " + face.ToString().ToLower() + (type != null ? " " + type.ToString() : "") + " damage";
         }
 
+        public override GenericAction Clone()
+        {
+            return new RepairAction(damageCardFace, criticalCardType);
+        }
+
         public override void ActionTake()
         {
             if (PayRepairCost())


### PR DESCRIPTION
Actions now have their own Clone method which must be overridden for actions that require specific initialization

Fixes #3072 