### PR TITLE
Fixes #3357. Removed variable point cost from Hate upgrade

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/ForcePower/Hate.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/ForcePower/Hate.cs
@@ -4,7 +4,7 @@ using Upgrade;
 
 namespace UpgradesList.SecondEdition
 {
-    public class Hate : GenericUpgrade, IVariableCost
+    public class Hate : GenericUpgrade
     {
         public Hate() : base()
         {
@@ -17,18 +17,6 @@ namespace UpgradesList.SecondEdition
             );
 
             ImageUrl = "https://squadbuilder.fantasyflightgames.com/card_images/en/4a10b5c8a3d796116163a741d145f4e9.png";
-        }
-
-        public void UpdateCost(GenericShip ship)
-        {
-            Dictionary<BaseSize, int> sizeToCost = new Dictionary<BaseSize, int>()
-            {
-                {BaseSize.Small, 3},
-                {BaseSize.Medium, 6},
-                {BaseSize.Large, 9},
-            };
-
-            UpgradeInfo.Cost = sizeToCost[ship.ShipInfo.BaseSize];
         }
     }
 }


### PR DESCRIPTION
 Fixes #3357. Removed variable point cost from Hate upgrade which means it now uses the card info cost which was already at the correct points (4).