### PR TITLE
Fixes 3359

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIESeBomber/SienarJaemusTestPilot.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIESeBomber/SienarJaemusTestPilot.cs
@@ -1,0 +1,24 @@
+
+
+using System.Collections.Generic;
+using Upgrade;
+
+namespace Ship
+{
+    namespace SecondEdition.TIESeBomber
+    {
+        public class SienarJeamusTestPilot : TIESeBomber
+        {
+            public SienarJeamusTestPilot() : base()
+            {
+                PilotInfo = new PilotCardInfo(
+                    "Sienar-Jaemus Test Pilot",
+                    2,
+                    31
+                );
+
+                ImageUrl = "https://meta.listfortress.com/assets/pilots/sienarjaemustestpilot-4a274cc57c3edc4e4e7c2fa4ba5865ee58bf93163eae054390166bb9909d7a67.png";
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIESeBomber/SienarJaemusTestPilot.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIESeBomber/SienarJaemusTestPilot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88fbfcb77bc16e5409fc75f42daebd21
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIEWiWhisper/RedFuryZealot.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIEWiWhisper/RedFuryZealot.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using Upgrade;
+
+namespace Ship
+{
+    namespace SecondEdition.TIEWiWhisperModifiedInterceptor
+    {
+        public class RedFuryZealot : TIEWiWhisperModifiedInterceptor
+        {
+            public RedFuryZealot() : base()
+            {
+                PilotInfo = new PilotCardInfo(
+                    "Red Fury Zealot",
+                    2,
+                    44,
+                    extraUpgradeIcons: new List<UpgradeType>() { UpgradeType.Talent }
+                );
+
+                ImageUrl = "https://meta.listfortress.com/assets/pilots/redfuryzealot-f740cbbb920e579f88f70619b299e0e495411de02d130387ba3305071703c8ad.png";
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIEWiWhisper/RedFuryZealot.cs.meta
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIEWiWhisper/RedFuryZealot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 09f0579d51c97714985f64336fe3f556
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIEWiWhisper/Wrath.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Pilots/TIEWiWhisper/Wrath.cs
@@ -21,7 +21,7 @@ namespace Ship
                     53,
                     isLimited: true,
                     abilityType: typeof(Abilities.SecondEdition.WrathPilotAbility),
-                    extraUpgradeIcons: new List<UpgradeType>() { UpgradeType.Talent, UpgradeType.Talent }
+                    extraUpgradeIcons: new List<UpgradeType>() { UpgradeType.Talent }
                 );
 
                 ImageUrl = "https://i.imgur.com/AOPpXkq.png";

--- a/Assets/Scripts/Model/Content/SecondEdition/Ships/TIESeBomber.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Ships/TIESeBomber.cs
@@ -35,7 +35,8 @@ namespace Ship.SecondEdition.TIESeBomber
                     UpgradeType.Missile,
                     UpgradeType.Gunner,
                     UpgradeType.Device,
-                    UpgradeType.Configuration
+                    UpgradeType.Device,
+                    UpgradeType.Modification
                 )
             );
 

--- a/Assets/Scripts/Model/Content/SecondEdition/Ships/TIEWiWhisperModifiedInterceptor.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Ships/TIEWiWhisperModifiedInterceptor.cs
@@ -30,6 +30,7 @@ namespace Ship.SecondEdition.TIEWiWhisperModifiedInterceptor
                 (
                     UpgradeType.Missile,
                     UpgradeType.Tech,
+                    UpgradeType.Tech,
                     UpgradeType.Configuration     
                 )
             );


### PR DESCRIPTION
 Fixes 3359 (minus Hate and Brilliant Evasion points cost which are fixed in pull/#3384 and pull/#3387)

- Added Red Fury Zealot to TIE Whisper.
- Fixed TIE Whisper upgrade slots so they now 2 tech slots instead of 1.
- Fixed Wrath (TIE Whisper) so it has 1 talent instead of 2.
- Added Sienar-Jaemus Test Pilot to TIE se Bomber.
- Fixed TIE se Bomber upgrade slots so they now have 2 payload (device) and switched configuration for modification.