### PR TITLE
Fix issue with The Child's Merciless Pursuit Condition

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/TheChild.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/TheChild.cs
@@ -178,6 +178,7 @@ namespace Conditions
             CachedAttacker = null;
             CachedDefender = null;
             DecisionSubPhase.ConfirmDecisionNoCallback();
+            //Without these two additional calls, the game gets stuck in the SelectTargetForAttackSubPhase.
             DecisionSubPhase.ConfirmDecisionNoCallback();
             DecisionSubPhase.ConfirmDecisionNoCallback();
         }

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/TheChild.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Crew/TheChild.cs
@@ -114,6 +114,9 @@ namespace Conditions
         public GenericUpgrade SourceUpgrade;
         public UpgradesList.SecondEdition.TheChild TheChild;
 
+        private GenericShip CachedAttacker;
+        private GenericShip CachedDefender;
+
         public MercilessPursuitCondition(GenericShip host) : base(host)
         {
             Name = ImageName = "Merciless Pursuit Condition";
@@ -136,6 +139,8 @@ namespace Conditions
         {
             if (Combat.Defender.UpgradeBar.HasUpgradeInstalled(typeof(UpgradesList.SecondEdition.TheChild)))
             {
+                CachedAttacker = Combat.Attacker;
+                CachedDefender = Combat.Defender;
                 Triggers.RegisterTrigger
                 (
                     new Trigger()
@@ -153,7 +158,6 @@ namespace Conditions
         {
             MercilessPursuitDecisionSubphase subphase = Phases.StartTemporarySubPhaseNew<MercilessPursuitDecisionSubphase>("Merciless Pursuit Decision", Triggers.FinishTrigger);
 
-
             subphase.DescriptionShort = "Merciless Pursuit";
             subphase.DescriptionLong = "Do you want to acquire a lock on the defender?";
             subphase.ImageSource = TheChild;
@@ -169,10 +173,13 @@ namespace Conditions
 
         private void AcquireLock(object sender, EventArgs e)
         {
+            Messages.ShowInfo($"Merciless Pursuit: {CachedAttacker.PilotInfo.PilotName} aquires a lock on {CachedDefender.PilotInfo.PilotName}");
+            ActionsHolder.AcquireTargetLock(CachedAttacker, CachedDefender, Triggers.FinishTrigger, Triggers.FinishTrigger);
+            CachedAttacker = null;
+            CachedDefender = null;
             DecisionSubPhase.ConfirmDecisionNoCallback();
-
-            Messages.ShowInfo($"Merciless Pursuit: {Combat.Attacker.PilotInfo.PilotName} aquires a lock on {Combat.Defender.PilotInfo.PilotName}");
-            ActionsHolder.AcquireTargetLock(Combat.Attacker, Combat.Defender, Triggers.FinishTrigger, Triggers.FinishTrigger);
+            DecisionSubPhase.ConfirmDecisionNoCallback();
+            DecisionSubPhase.ConfirmDecisionNoCallback();
         }
 
         private void SkipLock(object sender, EventArgs e)


### PR DESCRIPTION
The root issue was that by the time the condition was being resolved, the Combat object no longer had the Attacker and Defender set:
![image](https://user-images.githubusercontent.com/4753012/143721203-f3fe061b-4aff-464c-a3d2-3924329f9652.png)

However, after fixing this by caching those values, the game would hang indefinitely. It would be stuck in the SelectTargetForAttackSubPhase.

![image](https://user-images.githubusercontent.com/4753012/143721235-574d5b2c-1beb-4303-8de2-8595b599018c.png)

Two additional calls to `DecisionSubPhase.ConfirmDecisionNoCallback` would clear up the logjam.

I'm sure this probably isn't the _preferred_ way to clear out the issue, but I'm not so familiar with the codebase, so this solution is here because it works. I'm definitely open to having a discussion about a better way of resolving the issue!

Cases tested:
- Player has Mando + Child. AI has two Bounty Hunters. After Bounty Hunters fire, they take a target lock on Mando. (Prior to this fix, this would crash)
- Player has two Bounty Hunters, AI has Mando + Child. After every shot on Mando, the Bounty Hunters were presented with the chance to take the target lock on Mando or not. Both options were tested and worked as expected.

Fixes #3339
Fixes #3350 