### PR TITLE
#3330 Daredevil bug on T65 X-Wing

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Ships/T65XWing.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Ships/T65XWing.cs
@@ -18,7 +18,7 @@ namespace Ship
                 ShipInfo.UpgradeIcons.Upgrades.Add(UpgradeType.Configuration);
                 ShipInfo.ActionIcons.AddActions(new ActionInfo(typeof(BarrelRollAction)));
 
-                DefaultUpgrades.Add(typeof(UpgradesList.SecondEdition.ServomotorSFoilsAttack));
+                DefaultUpgrades.Add(typeof(UpgradesList.SecondEdition.ServomotorSFoilsClosed));
 
                 DialInfo.ChangeManeuverComplexity(new ManeuverHolder(ManeuverSpeed.Speed2, ManeuverDirection.Left, ManeuverBearing.Bank), MovementComplexity.Easy);
                 DialInfo.ChangeManeuverComplexity(new ManeuverHolder(ManeuverSpeed.Speed2, ManeuverDirection.Right, ManeuverBearing.Bank), MovementComplexity.Easy);

--- a/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Configuration/ServomotorSFoils.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Upgrades/Configuration/ServomotorSFoils.cs
@@ -12,7 +12,6 @@ namespace UpgradesList.SecondEdition
     {
         public ServomotorSFoilsClosed() : base()
         {
-            IsHidden = true;
             NameCanonical = "servomotorsfoils-anotherside";
 
             UpgradeInfo = new UpgradeCardInfo(


### PR DESCRIPTION
Suggested fix is to default config to 'Closed' side. I also made both sides visible as I thought that added clarity. If they aren't both visible then there's a weird situation where if you remove the 'Closed' configuration then you can't re-add it.